### PR TITLE
Add quilt as a build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,8 @@ Build-Depends: cdbs,
                libwacom-dev (>= 0.4),
                xserver-xorg-input-wacom,
                libgnomekbd-dev (>= 3.4.0),
-               libxklavier-dev
+               libxklavier-dev,
+               quilt
 Standards-Version: 3.9.3
 Homepage: http://cinnamon.linuxmint.com
 

--- a/debian/control.in
+++ b/debian/control.in
@@ -34,7 +34,8 @@ Build-Depends: cdbs,
                libwacom-dev (>= 0.4),
                xserver-xorg-input-wacom,
                libgnomekbd-dev (>= 3.4.0),
-               libxklavier-dev
+               libxklavier-dev,
+               quilt
 Standards-Version: 3.9.3
 Homepage: http://cinnamon.linuxmint.com
 


### PR DESCRIPTION
Debuild complains about a lintian error from a missing build dependency for quilt. This patch fixes the oversight. CSD has a quilt series already so this should've been a build-dependency already.
