### PR TITLE
[upower] fix lid suspend with upower-0.99

### DIFF
--- a/plugins/power/csd-power-manager.c
+++ b/plugins/power/csd-power-manager.c
@@ -2215,7 +2215,11 @@ do_lid_closed_action (CsdPowerManager *manager)
 
 
 static void
+#if UP_CHECK_VERSION(0,99,0)
+lid_state_changed_cb (UpClient *client, GParamSpec *pspec, CsdPowerManager *manager)
+#else
 up_client_changed_cb (UpClient *client, CsdPowerManager *manager)
+#endif
 {
         gboolean tmp;
 
@@ -3967,8 +3971,13 @@ csd_power_manager_start (CsdPowerManager *manager,
                           G_CALLBACK (engine_device_removed_cb), manager);
         g_signal_connect (manager->priv->up_client, "device-changed",
                           G_CALLBACK (engine_device_changed_cb), manager);
+#if UP_CHECK_VERSION(0,99,0)
+        g_signal_connect_after (manager->priv->up_client, "notify::lid-is-closed",
+                                G_CALLBACK (lid_state_changed_cb), manager);
+#else
         g_signal_connect_after (manager->priv->up_client, "changed",
                                 G_CALLBACK (up_client_changed_cb), manager);
+#endif
 
         /* use the fallback name from gnome-power-manager so the shell
          * blocks this, and uses the power extension instead */


### PR DESCRIPTION
fixes https://github.com/linuxmint/Cinnamon/issues/3054

based on Only listen to lid-is-closed changing patch from

https://bugzilla.gnome.org/show_bug.cgi?id=709736
