### PR TITLE
[upower-0.99] power: Use logind to discover critical action availability

### DIFF
--- a/plugins/power/csd-power-manager.c
+++ b/plugins/power/csd-power-manager.c
@@ -1204,7 +1204,7 @@ manager_critical_action_get (CsdPowerManager *manager,
                         policy = CSD_POWER_ACTION_SHUTDOWN;
                 g_variant_unref (result);
         } else {
-                policy = CSD_POWER_ACTION_SHUTDOWN
+                policy = CSD_POWER_ACTION_SHUTDOWN;
 #else
                 if (up_client_get_can_hibernate (manager->priv->up_client))
                         return policy;


### PR DESCRIPTION
based on two upstream commits

https://git.gnome.org/browse/gnome-settings-daemon/commit/plugins/power/gsd-power-manager.c?h=gnome-3-12&id=0c5fd82a6ce25abca9a9d7018889bad8fc1c6057

and

https://git.gnome.org/browse/gnome-settings-daemon/commit/plugins/power/gsd-power-manager.c?h=gnome-3-12&id=e7b2835443d4e0bbb4d379de0b9dcae5c36bebfe
