### PR TITLE
[upower-0.99] Use Upower for critical actions

### DIFF
--- a/plugins/power/csd-power-manager.c
+++ b/plugins/power/csd-power-manager.c
@@ -1198,7 +1198,7 @@ manager_critical_action_do (CsdPowerManager *manager,
 {
 #if ! UP_CHECK_VERSION(0,99,0)
         CsdPowerActionType action_type;
-
+#endif
 
         /* stop playing the alert as it's too late to do anything now */
         if (manager->priv->critical_alert_timeout_id > 0)


### PR DESCRIPTION
based on

https://git.gnome.org/browse/gnome-settings-daemon/commit/plugins/power/gsd-power-manager.c?h=gnome-3-12&id=1ba59178b4379f38874498a437104914b85c1104

and

https://git.gnome.org/browse/gnome-settings-daemon/commit/plugins/power/gsd-power-manager.c?h=gnome-3-12&id=8e6a82c585fe16978f9e1ca3437a4b96dd4e6d34
