### PR TITLE
Update csd-power-manager.c

### DIFF
--- a/plugins/power/csd-power-manager.c
+++ b/plugins/power/csd-power-manager.c
@@ -3466,7 +3466,7 @@ power_keyboard_proxy_ready_cb (GObject             *source_object,
 
         /* set brightness to max if not currently set so is something
          * sensible */
-        if (manager->priv->kbd_brightness_now <= 0) {
+        if (manager->priv->kbd_brightness_now  < 0) {
                 gboolean ret;
                 ret = upower_kbd_set_brightness (manager,
                                                  manager->priv->kbd_brightness_max,


### PR DESCRIPTION
Let the user disable the keyboard backlight.

This also fixes the bug where a user could disable the keyboard backlight in his session, but it would always be reset after each login or screen-unlock.

See https://bugzilla.gnome.org/show_bug.cgi?id=734074
