### PR TITLE
Set keyboard backlight to zero instead max value.

### DIFF
--- a/plugins/power/csd-power-manager.c
+++ b/plugins/power/csd-power-manager.c
@@ -3464,16 +3464,16 @@ power_keyboard_proxy_ready_cb (GObject             *source_object,
         g_variant_get (k_now, "(i)", &manager->priv->kbd_brightness_now);
         g_variant_get (k_max, "(i)", &manager->priv->kbd_brightness_max);
 
-        /* set brightness to max if not currently set so is something
-         * sensible */
-        if (manager->priv->kbd_brightness_now  < 0) {
+        /* Set keyboard brightness to zero if the current value is out of valid range.
+        Unlike display brightness, keyboard backlight brightness should be dim by default.*/
+        if ((manager->priv->kbd_brightness_now  < 0) || (manager->priv->kbd_brightness_now > manager->priv->kbd_brightness_max)) {
                 gboolean ret;
                 ret = upower_kbd_set_brightness (manager,
-                                                 manager->priv->kbd_brightness_max,
+                                                 0,
                                                  &error);
                 if (!ret) {
                         g_warning ("failed to initialize kbd backlight to %i: %s",
-                                   manager->priv->kbd_brightness_max,
+                                   0,
                                    error->message);
                         g_error_free (error);
                 }


### PR DESCRIPTION
If the keyboard backlight brightness value is not set by the user or outside the valid range, it is disabled instead of being set to maximum brightness. Disabled keyboard backlight also increases battery life by lower power consumption (keyboard backlight at maximum brightness can consume up to 0.7 W).

Most users disable keyboard backlight and use it only for exceptional circumstances, like working at night in an unilluminated workspace.
