### PR TITLE
Add support for GTK3 Gtk/DecorationLayout setting

### DIFF
--- a/plugins/xsettings/csd-xsettings-manager.c
+++ b/plugins/xsettings/csd-xsettings-manager.c
@@ -355,6 +355,7 @@ static TranslationEntry translations [] = {
         { "org.cinnamon.desktop.interface", "gtk-timeout-initial",    "Gtk/TimeoutInitial",      translate_int_int },
         { "org.cinnamon.desktop.interface", "gtk-timeout-repeat",     "Gtk/TimeoutRepeat",       translate_int_int },
         { "org.cinnamon.desktop.interface", "gtk-color-scheme",       "Gtk/ColorScheme",         translate_string_string },
+        { "org.cinnamon.desktop.interface", "gtk-decoration-layout",  "Gtk/DecorationLayout",    translate_string_string },
         { "org.cinnamon.desktop.interface", "gtk-im-preedit-style",   "Gtk/IMPreeditStyle",      translate_string_string },
         { "org.cinnamon.desktop.interface", "gtk-im-status-style",    "Gtk/IMStatusStyle",       translate_string_string },
         { "org.cinnamon.desktop.interface", "gtk-im-module",          "Gtk/IMModule",            translate_string_string },


### PR DESCRIPTION
Needed for gtk-3.12 CSD changes (needs https://github.com/linuxmint/cinnamon-desktop/pull/23)

https://github.com/mate-desktop/mate-settings-daemon/commit/1ed94d5aed85afbfad570cc76bc9ca26cdaba39f
