### PR TITLE
Fix power button asking what to do even when set to just do it

### DIFF
--- a/plugins/media-keys/csd-media-keys-manager.c
+++ b/plugins/media-keys/csd-media-keys-manager.c
@@ -1384,7 +1384,8 @@ do_config_power_action (CsdMediaKeysManager *manager,
                 cinnamon_session_shutdown (manager);
                 break;
         case CSD_POWER_ACTION_SHUTDOWN:
-                execute (manager, "cinnamon-session-quit --power-off --no-prompt", FALSE);
+                //FIXME: A wee bit cheating here...
+                execute (manager, "dbus-send --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.RequestShutdown", FALSE);
                 break;
         case CSD_POWER_ACTION_HIBERNATE:
                 csd_power_hibernate (manager->priv->upower_proxy);


### PR DESCRIPTION
Fixes: https://github.com/linuxmint/Roadmap#consider-for-mint-171 - The power button set to “shut down immediately” still ‘asks’

Because cinnamon-session-quit [--no-prompt] only works with [--login]
