### PR TITLE
xrandr: Don't operate on a NULL object

### DIFF
--- a/plugins/xrandr/csd-xrandr-manager.c
+++ b/plugins/xrandr/csd-xrandr-manager.c
@@ -877,6 +877,8 @@ make_clone_setup (CsdXrandrManager *manager, GnomeRRScreen *screen)
                 return NULL;
 
         result = gnome_rr_config_new_current (screen, NULL);
+        gnome_rr_config_set_clone (result, TRUE);
+
         outputs = gnome_rr_config_get_outputs (result);
 
         for (i = 0; outputs[i] != NULL; ++i) {
@@ -917,8 +919,6 @@ make_clone_setup (CsdXrandrManager *manager, GnomeRRScreen *screen)
                 g_object_unref (G_OBJECT (result));
                 result = NULL;
         }
-
-        gnome_rr_config_set_clone (result, TRUE);
 
         print_configuration (result, "clone setup");
 
@@ -1001,6 +1001,8 @@ make_laptop_setup (CsdXrandrManager *manager, GnomeRRScreen *screen)
         GnomeRROutputInfo **outputs = gnome_rr_config_get_outputs (result);
         int i;
 
+        gnome_rr_config_set_clone (result, FALSE);
+
         for (i = 0; outputs[i] != NULL; ++i) {
                 GnomeRROutputInfo *info = outputs[i];
 
@@ -1016,12 +1018,11 @@ make_laptop_setup (CsdXrandrManager *manager, GnomeRRScreen *screen)
                 }
         }
 
+
         if (config_is_all_off (result)) {
                 g_object_unref (G_OBJECT (result));
                 result = NULL;
         }
-
-        gnome_rr_config_set_clone (result, FALSE);
 
         print_configuration (result, "Laptop setup");
 
@@ -1143,6 +1144,8 @@ make_xinerama_setup (CsdXrandrManager *manager, GnomeRRScreen *screen)
         int i;
         int x;
 
+        gnome_rr_config_set_clone (result, FALSE);
+
         x = 0;
         for (i = 0; outputs[i] != NULL; ++i) {
                 GnomeRROutputInfo *info = outputs[i];
@@ -1171,8 +1174,6 @@ make_xinerama_setup (CsdXrandrManager *manager, GnomeRRScreen *screen)
                 result = NULL;
         }
 
-        gnome_rr_config_set_clone (result, FALSE);
-
         print_configuration (result, "xinerama setup");
 
         return result;
@@ -1188,6 +1189,8 @@ make_other_setup (GnomeRRScreen *screen)
         GnomeRRConfig *result = gnome_rr_config_new_current (screen, NULL);
         GnomeRROutputInfo **outputs = gnome_rr_config_get_outputs (result);
         int i;
+
+        gnome_rr_config_set_clone (result, FALSE);
 
         for (i = 0; outputs[i] != NULL; ++i) {
                 GnomeRROutputInfo *info = outputs[i];
@@ -1205,8 +1208,6 @@ make_other_setup (GnomeRRScreen *screen)
                 g_object_unref (G_OBJECT (result));
                 result = NULL;
         }
-
-        gnome_rr_config_set_clone (result, FALSE);
 
         print_configuration (result, "other setup");
 


### PR DESCRIPTION
Based on 

https://git.gnome.org/browse/gnome-settings-daemon/patch/plugins?id=92b5f78720c788e730d17b40f5ec52e129aa8bee

To fix

(cinnamon-settings-daemon:1642): CinnamonDesktop-CRITICAL **: gnome_rr_config_set_clone: assertion 'GNOME_IS_RR_CONFIG (self)' failed