### PR TITLE
Change the default of scroll-method key to two-finger-scrolling

### DIFF
--- a/data/org.cinnamon.settings-daemon.peripherals.gschema.xml.in.in
+++ b/data/org.cinnamon.settings-daemon.peripherals.gschema.xml.in.in
@@ -26,7 +26,7 @@
       <_description>Set this to TRUE to allow horizontal scrolling by the same method selected with the scroll_method key.</_description>
     </key>
     <key name="scroll-method" enum="org.cinnamon.settings-daemon.CsdTouchpadScrollMethod">
-      <default>'edge-scrolling'</default>
+      <default>'two-finger-scrolling'</default>
       <_summary>Select the touchpad scroll method</_summary>
       <_description>Select the touchpad scroll method. Supported values are: "disabled", "edge-scrolling", "two-finger-scrolling".</_description>
     </key>


### PR DESCRIPTION
Reasoning: Most modern laptops don't have an explicit edge for scrolling anymore on touchpads, and instead are more comfortable using two fingers to scroll with a flat and wide surface