### PR TITLE
xsettings: fix some settings not being updated after recent glib change

### DIFF
--- a/plugins/xsettings/csd-xsettings-manager.c
+++ b/plugins/xsettings/csd-xsettings-manager.c
@@ -934,6 +934,12 @@ cinnamon_xsettings_manager_start (CinnamonSettingsXSettingsManager *manager,
         g_hash_table_insert (manager->priv->settings,
                              PRIVACY_SETTINGS_SCHEMA, g_settings_new (PRIVACY_SETTINGS_SCHEMA));
 
+        list = g_hash_table_get_values (manager->priv->settings);
+        for (l = list; l != NULL; l = l->next) {
+                g_signal_connect_object (G_OBJECT (l->data), "changed", G_CALLBACK (xsettings_callback), manager, 0);
+        }
+        g_list_free (list);
+
         for (i = 0; i < G_N_ELEMENTS (translations); i++) {
                 GVariant *val;
                 GSettings *settings;
@@ -950,12 +956,6 @@ cinnamon_xsettings_manager_start (CinnamonSettingsXSettingsManager *manager,
                 process_value (manager, &translations[i], val);
                 g_variant_unref (val);
         }
-
-        list = g_hash_table_get_values (manager->priv->settings);
-        for (l = list; l != NULL; l = l->next) {
-                g_signal_connect_object (G_OBJECT (l->data), "changed", G_CALLBACK (xsettings_callback), manager, 0);
-        }
-        g_list_free (list);
 
         /* Plugin settings (GTK modules and Xft) */
         manager->priv->plugin_settings = g_settings_new (XSETTINGS_PLUGIN_SCHEMA);


### PR DESCRIPTION
GSettings got changed to only emit the "changed" signal after get_value has been called at least once since connecting to the "changed" signal in order to prevent unnecessary work in some cases. The g-s-d xsettings plugin however was getting all values before connecting to the "changed" signal and thus the signal was not emitted for some of the settings, like the wm button-layout. Other settings (like the interface settings) were fine due to additional get_value calls after setting up the signal callback. Fix this by moving the moving the loop that gets all initial values after the connect calls. 

See also: 
https://git.gnome.org/browse/glib/commit/?id=8ff5668a458344da22d30491e3ce726d861b3619 https://bugzilla.gnome.org/show_bug.cgi?id=745135