### PR TITLE
Change the minimum height required to trigger HiDPI scaling.

### DIFF
--- a/plugins/xsettings/csd-xsettings-manager.c
+++ b/plugins/xsettings/csd-xsettings-manager.c
@@ -226,7 +226,7 @@
 /* The minimum screen height at which we turn on a window-scale of 2;
  * below this there just isn't enough vertical real estate for GNOME
  * apps to work, and it's better to just be tiny */
-#define HIDPI_MIN_HEIGHT 1200
+#define HIDPI_MIN_HEIGHT 1500
 
 typedef struct _TranslationEntry TranslationEntry;
 typedef void (* TranslationFunc) (CinnamonSettingsXSettingsManager *manager,


### PR DESCRIPTION
On newer laptops like the X1 Carbon the height is 1440, so it automatically does 2x HiDPI scaling. This isn't a great user experience out of the box, the text is bloated and menus are too large. Instead it should default to 1x scaling.