### PR TITLE
remove deprecated gdk_display_get_n_screens

### DIFF
--- a/plugins/background/csd-background-manager.c
+++ b/plugins/background/csd-background-manager.c
@@ -81,25 +81,28 @@ draw_background (CsdBackgroundManager *manager,
                  gboolean              use_crossfade)
 {
         GdkDisplay *display;
-        GdkScreen *screen;
-        GdkWindow *root_window;
-        cairo_surface_t *surface;
 
         cinnamon_settings_profile_start (NULL);
 
         display = gdk_display_get_default ();
 
-        screen = gdk_display_get_screen (display, 0);
+        if (display)
+        {
+            GdkScreen *screen;
+            GdkWindow *root_window;
+            cairo_surface_t *surface;
 
-        root_window = gdk_screen_get_root_window (screen);
+            screen = gdk_display_get_screen (display, 0);
 
-        surface = gnome_bg_create_surface (manager->priv->bg,
-                                           root_window,
-                                           gdk_screen_get_width (screen),
-                                           gdk_screen_get_height (screen),
-                                           TRUE);
+            root_window = gdk_screen_get_root_window (screen);
 
-        if (FALSE) {  /* use_crossfade - buggy now?  need to look at cinnamon-desktop */
+            surface = gnome_bg_create_surface (manager->priv->bg,
+                                               root_window,
+                                               gdk_screen_get_width (screen),
+                                               gdk_screen_get_height (screen),
+                                               TRUE);
+
+            if (FALSE) {  /* use_crossfade - buggy now?  need to look at cinnamon-desktop */
 
                 if (manager->priv->fade != NULL) {
                         g_object_unref (manager->priv->fade);
@@ -109,11 +112,12 @@ draw_background (CsdBackgroundManager *manager,
                 g_signal_connect_swapped (manager->priv->fade, "finished",
                                           G_CALLBACK (on_crossfade_finished),
                                           manager);
-        } else {
+            } else {
                 gnome_bg_set_surface_as_root (screen, surface);
-        }
+            }
 
-        cairo_surface_destroy (surface);
+            cairo_surface_destroy (surface);
+        }
 
         cinnamon_settings_profile_end (NULL);
 }
@@ -269,33 +273,41 @@ static void
 disconnect_screen_signals (CsdBackgroundManager *manager)
 {
         GdkDisplay *display;
-        GdkScreen *screen;
 
         display = gdk_display_get_default ();
 
-        screen = gdk_display_get_screen (display, 0);
-        g_signal_handlers_disconnect_by_func (screen,
-                                              G_CALLBACK (on_screen_size_changed),
-                                              manager);
+        if (display)
+        {
+            GdkScreen *screen;
+
+            screen = gdk_display_get_screen (display, 0);
+            g_signal_handlers_disconnect_by_func (screen,
+                                                  G_CALLBACK (on_screen_size_changed),
+                                                  manager);
+        }
 }
 
 static void
 connect_screen_signals (CsdBackgroundManager *manager)
 {
         GdkDisplay *display;
-        GdkScreen *screen;
 
         display = gdk_display_get_default ();
 
-        screen = gdk_display_get_screen (display, 0);
-        g_signal_connect (screen,
-                          "monitors-changed",
-                          G_CALLBACK (on_screen_size_changed),
-                          manager);
-        g_signal_connect (screen,
-                          "size-changed",
-                           G_CALLBACK (on_screen_size_changed),
-                           manager);
+        if (display)
+        {
+            GdkScreen *screen;
+
+            screen = gdk_display_get_screen (display, 0);
+            g_signal_connect (screen,
+                              "monitors-changed",
+                              G_CALLBACK (on_screen_size_changed),
+                              manager);
+            g_signal_connect (screen,
+                              "size-changed",
+                               G_CALLBACK (on_screen_size_changed),
+                               manager);
+        }
 }
 
 gboolean

--- a/plugins/background/csd-background-manager.c
+++ b/plugins/background/csd-background-manager.c
@@ -81,45 +81,39 @@ draw_background (CsdBackgroundManager *manager,
                  gboolean              use_crossfade)
 {
         GdkDisplay *display;
-        int         n_screens;
-        int         i;
+        GdkScreen *screen;
+        GdkWindow *root_window;
+        cairo_surface_t *surface;
 
         cinnamon_settings_profile_start (NULL);
 
         display = gdk_display_get_default ();
-        n_screens = gdk_display_get_n_screens (display);
 
-        for (i = 0; i < n_screens; ++i) {
-                GdkScreen *screen;
-                GdkWindow *root_window;
-                cairo_surface_t *surface;
+        screen = gdk_display_get_screen (display, 0);
 
-                screen = gdk_display_get_screen (display, i);
+        root_window = gdk_screen_get_root_window (screen);
 
-                root_window = gdk_screen_get_root_window (screen);
+        surface = gnome_bg_create_surface (manager->priv->bg,
+                                           root_window,
+                                           gdk_screen_get_width (screen),
+                                           gdk_screen_get_height (screen),
+                                           TRUE);
 
-                surface = gnome_bg_create_surface (manager->priv->bg,
-                                                   root_window,
-                                                   gdk_screen_get_width (screen),
-                                                   gdk_screen_get_height (screen),
-                                                   TRUE);
+        if (FALSE) {  /* use_crossfade - buggy now?  need to look at cinnamon-desktop */
 
-                if (FALSE) {  /* use_crossfade - buggy now?  need to look at cinnamon-desktop */
-
-                        if (manager->priv->fade != NULL) {
-                                g_object_unref (manager->priv->fade);
-                        }
-
-                        manager->priv->fade = gnome_bg_set_surface_as_root_with_crossfade (screen, surface);
-                        g_signal_connect_swapped (manager->priv->fade, "finished",
-                                                  G_CALLBACK (on_crossfade_finished),
-                                                  manager);
-                } else {
-                        gnome_bg_set_surface_as_root (screen, surface);
+                if (manager->priv->fade != NULL) {
+                        g_object_unref (manager->priv->fade);
                 }
 
-                cairo_surface_destroy (surface);
+                manager->priv->fade = gnome_bg_set_surface_as_root_with_crossfade (screen, surface);
+                g_signal_connect_swapped (manager->priv->fade, "finished",
+                                          G_CALLBACK (on_crossfade_finished),
+                                          manager);
+        } else {
+                gnome_bg_set_surface_as_root (screen, surface);
         }
+
+        cairo_surface_destroy (surface);
 
         cinnamon_settings_profile_end (NULL);
 }
@@ -275,43 +269,33 @@ static void
 disconnect_screen_signals (CsdBackgroundManager *manager)
 {
         GdkDisplay *display;
-        int         i;
-        int         n_screens;
+        GdkScreen *screen;
 
         display = gdk_display_get_default ();
-        n_screens = gdk_display_get_n_screens (display);
 
-        for (i = 0; i < n_screens; ++i) {
-                GdkScreen *screen;
-                screen = gdk_display_get_screen (display, i);
-                g_signal_handlers_disconnect_by_func (screen,
-                                                      G_CALLBACK (on_screen_size_changed),
-                                                      manager);
-        }
+        screen = gdk_display_get_screen (display, 0);
+        g_signal_handlers_disconnect_by_func (screen,
+                                              G_CALLBACK (on_screen_size_changed),
+                                              manager);
 }
 
 static void
 connect_screen_signals (CsdBackgroundManager *manager)
 {
         GdkDisplay *display;
-        int         i;
-        int         n_screens;
+        GdkScreen *screen;
 
         display = gdk_display_get_default ();
-        n_screens = gdk_display_get_n_screens (display);
 
-        for (i = 0; i < n_screens; ++i) {
-                GdkScreen *screen;
-                screen = gdk_display_get_screen (display, i);
-                g_signal_connect (screen,
-                                  "monitors-changed",
-                                  G_CALLBACK (on_screen_size_changed),
-                                  manager);
-                g_signal_connect (screen,
-                                  "size-changed",
-                                  G_CALLBACK (on_screen_size_changed),
-                                  manager);
-        }
+        screen = gdk_display_get_screen (display, 0);
+        g_signal_connect (screen,
+                          "monitors-changed",
+                          G_CALLBACK (on_screen_size_changed),
+                          manager);
+        g_signal_connect (screen,
+                          "size-changed",
+                           G_CALLBACK (on_screen_size_changed),
+                           manager);
 }
 
 gboolean


### PR DESCRIPTION
this is now hardcoded to return 1, so loops using this can be removed