### PR TITLE
xsettings: Fix cursor-size changes being ignored

### DIFF
--- a/plugins/xsettings/csd-xsettings-manager.c
+++ b/plugins/xsettings/csd-xsettings-manager.c
@@ -828,7 +828,8 @@ xsettings_callback (GSettings             *settings,
         GVariant         *value;
 
         if (g_str_equal (key, TEXT_SCALING_FACTOR_KEY) ||
-            g_str_equal (key, SCALING_FACTOR_KEY)) {
+            g_str_equal (key, SCALING_FACTOR_KEY) ||
+            g_str_equal (key, CURSOR_SIZE_KEY)) {
             xft_callback (NULL, key, manager);
             return;
 	}


### PR DESCRIPTION
Apps like firefox, thunderbird  ignore cursor-size changes, this pull request fixes the issue

based on

https://git.gnome.org/browse/gnome-settings-daemon/commit/?id=d4a833907f5ef0ef1e59b69faafb60293cc191d2