### PR TITLE
Wip/libinput support

### DIFF
--- a/plugins/common/csd-input-helper.c
+++ b/plugins/common/csd-input-helper.c
@@ -180,10 +180,12 @@ device_is_touchpad (XDevice *xdevice)
 
         /* we don't check on the type being XI_TOUCHPAD here,
          * but having a "Synaptics Off" property should be enough */
-
-        prop = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), "Synaptics Off", True);
-        if (!prop)
+        prop = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), "libinput Tapping Enabled", True);
+        if (!prop) {
+            prop = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), "Synaptics Off", True);
+            if (!prop)
                 return FALSE;
+        }
 
         gdk_error_trap_push ();
         if ((XGetDeviceProperty (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), xdevice, prop, 0, 1, False,

--- a/plugins/common/csd-input-helper.c
+++ b/plugins/common/csd-input-helper.c
@@ -181,7 +181,7 @@ device_is_touchpad (XDevice *xdevice)
         /* we don't check on the type being XI_TOUCHPAD here,
          * but having a "Synaptics Off" property should be enough */
 
-        prop = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), "Synaptics Off", False);
+        prop = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), "Synaptics Off", True);
         if (!prop)
                 return FALSE;
 

--- a/plugins/mouse/csd-mouse-manager.c
+++ b/plugins/mouse/csd-mouse-manager.c
@@ -311,6 +311,16 @@ bail:
         return FALSE;
 }
 
+static Atom
+property_from_name (const char *property_name)
+{
+        Atom prop;
+
+        prop = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), property_name, True);
+
+        return prop;
+}
+
 static gboolean
 touchpad_has_single_button (XDevice *device)
 {
@@ -321,7 +331,7 @@ touchpad_has_single_button (XDevice *device)
         gboolean is_single_button = FALSE;
         int rc;
 
-        prop = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), "Synaptics Capabilities", False);
+        prop = property_from_name ("Synaptics Capabilities");
         if (!prop)
                 return FALSE;
 
@@ -509,8 +519,7 @@ set_middle_button (CsdMouseManager *manager,
         unsigned char *data;
         int rc;
 
-        prop = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
-                            "Evdev Middle Button Emulation", True);
+        prop = property_from_name ("Evdev Middle Button Emulation");
 
         if (!prop) /* no evdev devices */
                 return;
@@ -638,7 +647,7 @@ set_tap_to_click (GdkDevice *device,
         unsigned char* data;
         Atom prop, type;
 
-        prop = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), "Synaptics Tap Action", False);
+        prop = property_from_name ("Synaptics Tap Action");
         if (!prop)
                 return;
 
@@ -691,7 +700,7 @@ set_click_actions (GdkDevice *device,
         unsigned char* data;
         Atom prop, type;
 
-        prop = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), "Synaptics Click Action", False);
+        prop = property_from_name ("Synaptics Click Action");
         if (!prop)
                 return;
 
@@ -735,7 +744,7 @@ static void synaptics_set_bool (GdkDevice *device, const char * property_name, i
     unsigned long nitems, bytes_after;
     unsigned char *data;
 
-    property = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), property_name, False);
+    property = property_from_name (property_name);
     if (!property) {
         return;  
     }
@@ -982,8 +991,7 @@ set_natural_scroll (CsdMouseManager *manager,
                  natural_scroll ? "natural (reverse) scroll" : "normal scroll",
                  gdk_device_get_name (device));
 
-        scrolling_distance = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
-                                          "Synaptics Scrolling Distance", False);
+        scrolling_distance = property_from_name ("Synaptics Scrolling Distance");
 
         gdk_error_trap_push ();
         rc = XGetDeviceProperty (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), xdevice,

--- a/plugins/mouse/csd-mouse-manager.c
+++ b/plugins/mouse/csd-mouse-manager.c
@@ -359,7 +359,7 @@ set_left_handed (CsdMouseManager *manager,
         if (xdevice == NULL)
                 return;
 
-	g_debug ("setting handedness on %s", gdk_device_get_name (device));
+        g_debug ("setting handedness on %s", gdk_device_get_name (device));
 
         buttons = g_new (guchar, buttons_capacity);
 
@@ -396,7 +396,7 @@ set_left_handed (CsdMouseManager *manager,
 
         configure_button_layout (buttons, n_buttons, left_handed);
 
-	gdk_error_trap_push ();
+        gdk_error_trap_push ();
         XSetDeviceButtonMapping (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), xdevice, buttons, n_buttons);
         gdk_error_trap_pop_ignored ();
 
@@ -423,7 +423,7 @@ set_motion (CsdMouseManager *manager,
         if (xdevice == NULL)
                 return;
 
-	g_debug ("setting motion on %s", gdk_device_get_name (device));
+        g_debug ("setting motion on %s", gdk_device_get_name (device));
 
         if (device_is_touchpad (xdevice))
                 settings = manager->priv->touchpad_settings;
@@ -519,7 +519,7 @@ set_middle_button (CsdMouseManager *manager,
         if (xdevice == NULL)
                 return;
 
-	g_debug ("setting middle button on %s", gdk_device_get_name (device));
+        g_debug ("setting middle button on %s", gdk_device_get_name (device));
 
         gdk_error_trap_push ();
 
@@ -651,7 +651,7 @@ set_tap_to_click (GdkDevice *device,
                 return;
         }
 
-	g_debug ("setting tap to click on %s", gdk_device_get_name (device));
+        g_debug ("setting tap to click on %s", gdk_device_get_name (device));
 
         gdk_error_trap_push ();
         rc = XGetDeviceProperty (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), xdevice, prop, 0, 2,
@@ -659,9 +659,9 @@ set_tap_to_click (GdkDevice *device,
                                  &bytes_after, &data);
 
         if (rc == Success && type == XA_INTEGER && format == 8 && nitems >= 7) {
-               /* Set MR mapping for corner tapping on the right side*/
-               data[0] = (state) ? 2 : 0;
-               data[1] = (state) ? 3 : 0;
+                /* Set MR mapping for corner tapping on the right side*/
+                data[0] = (state) ? 2 : 0;
+                data[1] = (state) ? 3 : 0;
 
                 /* Set RLM mapping for 1/2/3 fingers*/
                 data[4] = (state) ? ((left_handed) ? 3 : 1) : 0;
@@ -704,7 +704,7 @@ set_click_actions (GdkDevice *device,
                 return;
         }
 
-    g_debug ("setting click action to click on %s", gdk_device_get_name (device));
+        g_debug ("setting click action to click on %s", gdk_device_get_name (device));
 
         gdk_error_trap_push ();
         rc = XGetDeviceProperty (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), xdevice, prop, 0, 2,

--- a/plugins/mouse/csd-mouse-manager.c
+++ b/plugins/mouse/csd-mouse-manager.c
@@ -698,9 +698,9 @@ set_disable_w_typing (CsdMouseManager *manager, gboolean state)
 }
 
 static void
-set_tap_to_click (GdkDevice *device,
-                  gboolean   state,
-                  gboolean   left_handed)
+set_tap_to_click_synaptics (GdkDevice *device,
+                            gboolean   state,
+                            gboolean   left_handed)
 {
         int format, rc;
         unsigned long nitems, bytes_after;
@@ -748,6 +748,26 @@ set_tap_to_click (GdkDevice *device,
                 g_warning ("Error in setting tap to click on \"%s\"", gdk_device_get_name (device));
 
         xdevice_close (xdevice);
+}
+
+static void
+set_tap_to_click_libinput (GdkDevice *device, gboolean state)
+{
+        g_debug ("setting tap to click on %s", gdk_device_get_name (device));
+
+        touchpad_set_bool (device, "libinput Tapping Enabled", 0, state);
+}
+
+static void
+set_tap_to_click (GdkDevice *device,
+                  gboolean   state,
+                  gboolean   left_handed)
+{
+        if (property_from_name ("Synaptics Tap Action"))
+                set_tap_to_click_synaptics (device, state, left_handed);
+
+        if (property_from_name ("libinput Tapping Enabled"))
+                set_tap_to_click_libinput (device, state);
 }
 
 static void

--- a/plugins/mouse/csd-mouse-manager.c
+++ b/plugins/mouse/csd-mouse-manager.c
@@ -351,10 +351,13 @@ touchpad_has_single_button (XDevice *device)
 }
 
 static void
-touchpad_set_bool (GdkDevice *device, const char * property_name, int property_index, gboolean enable)
+property_set_bool (GdkDevice *device,
+                   XDevice *xdevice,
+                   const char * property_name,
+                   int property_index,
+                   gboolean enable)
 {
         int rc;
-        XDevice *xdevice;
         Atom act_type, property;
         int act_format;
         unsigned long nitems, bytes_after;
@@ -362,16 +365,6 @@ touchpad_set_bool (GdkDevice *device, const char * property_name, int property_i
 
         property = property_from_name (property_name);
         if (!property) {
-                return;
-        }
-
-        xdevice = open_gdk_device (device);
-        if (xdevice == NULL) {
-                return;
-        }
-
-        if (!device_is_touchpad (xdevice)) {
-                xdevice_close (xdevice);
                 return;
         }
 
@@ -401,6 +394,19 @@ touchpad_set_bool (GdkDevice *device, const char * property_name, int property_i
         if (gdk_error_trap_pop ()) {
                 g_warning ("Error while setting %s on \"%s\"", property_name, gdk_device_get_name (device));
         }
+}
+
+static void
+touchpad_set_bool (GdkDevice *device, const char * property_name, int property_index, gboolean enable)
+{
+        XDevice *xdevice;
+
+        xdevice = open_gdk_device (device);
+        if (xdevice == NULL)
+                return;
+
+        if (device_is_touchpad (xdevice))
+                property_set_bool (device, xdevice, property_name, property_index, enable);
 
         xdevice_close (xdevice);
 }

--- a/plugins/mouse/csd-mouse-manager.c
+++ b/plugins/mouse/csd-mouse-manager.c
@@ -995,9 +995,9 @@ set_mouse_settings (CsdMouseManager *manager,
 }
 
 static void
-set_natural_scroll (CsdMouseManager *manager,
-                    GdkDevice       *device,
-                    gboolean         natural_scroll)
+set_natural_scroll_synaptics (CsdMouseManager *manager,
+                              GdkDevice       *device,
+                              gboolean         natural_scroll)
 {
         XDevice *xdevice;
         Atom scrolling_distance, act_type;
@@ -1052,6 +1052,30 @@ set_natural_scroll (CsdMouseManager *manager,
                 XFree (data);
 
         xdevice_close (xdevice);
+}
+
+static void
+set_natural_scroll_libinput (CsdMouseManager *manager,
+                             GdkDevice       *device,
+                             gboolean         natural_scroll)
+{
+        g_debug ("Trying to set %s for \"%s\"",
+                 natural_scroll ? "natural (reverse) scroll" : "normal scroll",
+                 gdk_device_get_name (device));
+
+        touchpad_set_bool (device, "libinput Natural Scrolling Enabled", 0, natural_scroll);
+}
+
+static void
+set_natural_scroll (CsdMouseManager *manager,
+                    GdkDevice       *device,
+                    gboolean         natural_scroll)
+{
+        if (property_from_name ("Synaptics Scrolling Distance"))
+                set_natural_scroll_synaptics (manager, device, natural_scroll);
+
+        if (property_from_name ("libinput Natural Scrolling Enabled"))
+                set_natural_scroll_libinput (manager, device, natural_scroll);
 }
 
 static void


### PR DESCRIPTION
Fixes #78 

Add libinput support. Done cooperatively with other drivers, so most of the bits toggle the bit that exists on the device. This should in theory even support two touchpads, one with synaptics and one with libinput, and just DTRT.

The keys don't all map into libinput config options, so I took a best guess where needed.

I wouldn't mind if someone could do a bit more testing though, happy to merge/squash any patches.