### PR TITLE
Migrate away from gnome-common deprecated vars and macros

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,22 +1,39 @@
-#!/bin/bash
+#!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="cinnamon-settings-daemon"
-REQUIRED_AUTOMAKE_VERSION=1.10
+cd $srcdir
 
-(test -f $srcdir/configure.ac \
-  && test -d $srcdir/plugins) || {
-    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
-    echo " top-level cinnamon-settings-daemon directory"
+(test -f configure.ac) || {
+    echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
     exit 1
 }
 
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common from GNOME Subversion (or from"
-    echo "your distribution's package manager)."
-    exit 1
-}
-USE_GNOME2_MACROS=1 USE_COMMON_DOC_BUILD=yes . gnome-autogen.sh
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
+
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+    echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+    echo "*** If you wish to pass any to it, please specify them on the" >&2
+    echo "*** '$0' command line." >&2
+    echo "" >&2
+fi
+
+aclocal --install || exit 1
+glib-gettextize --force --copy || exit 1
+intltoolize --force --copy --automake || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+    $srcdir/configure "$@" || exit 1
+
+    if [ "$1" = "--help" ]; then exit 0 else
+        echo "Now type 'make' to compile $PKG_NAME" || exit 1
+    fi
+else
+    echo "Skipping configure process."
+fi

--- a/cinnamon-settings-daemon/Makefile.am
+++ b/cinnamon-settings-daemon/Makefile.am
@@ -1,10 +1,10 @@
 NULL =
 
-INCLUDES = \
+AM_CPPFLAGS = \
 	-DDATADIR=\""$(datadir)"\"				\
 	-DCINNAMON_SETTINGS_LOCALEDIR=\""$(datadir)/locale"\"	\
 	-DLIBEXECDIR=\""$(libexecdir)"\" 			\
-	-DCINNAMON_SETTINGS_PLUGINDIR=\""$(plugindir)"\"		\
+	-DCINNAMON_SETTINGS_PLUGINDIR=\""$(plugindir)"\"	\
 	$(WARN_CFLAGS)						\
 	$(DISABLE_DEPRECATED_CFLAGS)				\
 	$(SETTINGS_DAEMON_CFLAGS)				\
@@ -12,6 +12,10 @@ INCLUDES = \
 	$(GNOME_DESKTOP_CFLAGS)					\
 	$(LOGIND_CFLAGS)					\
 	$(NULL)
+
+AM_CFLAGS = $(WARN_CFLAGS)
+
+AM_LDFLAGS = $(WARN_LDFLAGS)
 
 privlibdir = $(pkglibdir)-$(CSD_API_VERSION)
 
@@ -28,9 +32,11 @@ libcsd_la_SOURCES =		\
 
 libcsd_la_CPPFLAGS = 		\
 	$(DISABLE_DEPRECATED_CFLAGS)	\
+	$(AM_CPPFLAGS)			\
 	$(NULL)
 
 libcsd_la_CFLAGS =		\
+	$(WARN_CFLAGS)		\
 	$(NULL)
 
 libcsd_la_LIBADD =		\
@@ -39,6 +45,7 @@ libcsd_la_LIBADD =		\
 	$(NULL)
 
 libcsd_la_LDFLAGS =		\
+	$(WARN_LDFLAGS)		\
 	-export-dynamic		\
 	-avoid-version		\
 	-no-undefined		\

--- a/configure.ac
+++ b/configure.ac
@@ -4,10 +4,13 @@ AC_INIT([cinnamon-settings-daemon],
         [3.0.1],
         [https://github.com/linuxmint/cinnamon-settings-daemon/issues])
 
+AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([cinnamon-settings-daemon/cinnamon-settings-manager.c])
 
 AM_INIT_AUTOMAKE([1.9 tar-ustar dist-xz no-dist-gzip check-news])
 AM_MAINTAINER_MODE([enable])
+
+m4_ifdef([AX_IS_RELEASE], [AX_IS_RELEASE([always])])
 
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
@@ -38,6 +41,9 @@ AM_GLIB_GNU_GETTEXT
 
 CSD_INTLTOOL_PLUGIN_RULE='%.cinnamon-settings-plugin:   %.cinnamon-settings-plugin.in   $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*.po) ; LC_ALL=C $(INTLTOOL_MERGE) -d -u -c $(top_builddir)/po/.intltool-merge-cache $(top_srcdir)/po $< [$]@'
 AC_SUBST([CSD_INTLTOOL_PLUGIN_RULE])
+
+m4_ifdef([AX_COMPILER_FLAGS],
+         [AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS])])
 
 dnl ---------------------------------------------------------------------------
 dnl - Dependencies
@@ -457,48 +463,6 @@ AM_CONDITIONAL(ENABLE_MAN, test "$enable_man" != no)
 dnl ---------------------------------------------------------------------------
 dnl - Finish
 dnl ---------------------------------------------------------------------------
-
-
-# Turn on the additional warnings last, so warnings don't affect other tests.
-
-AC_ARG_ENABLE(more-warnings,
-	[AC_HELP_STRING([--enable-more-warnings],
-	[Maximum compiler warnings])],
-	set_more_warnings="$enableval",[
-		if test -d $srcdir/.git; then
-			set_more_warnings=yes
-		else
-			set_more_warnings=no
-		fi
-        ])
-AC_MSG_CHECKING(for more warnings)
-if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
-        AC_MSG_RESULT(yes)
-        CFLAGS="\
-        -Wall \
-        -Wchar-subscripts -Wmissing-declarations -Wmissing-prototypes \
-        -Wnested-externs -Wpointer-arith \
-        -Wcast-align -Wsign-compare \
-        $CFLAGS"
-
-        for option in -Wno-strict-aliasing -Wno-sign-compare; do
-                SAVE_CFLAGS="$CFLAGS"
-                CFLAGS="$CFLAGS $option"
-                AC_MSG_CHECKING([whether gcc understands $option])
-                AC_TRY_COMPILE([], [],
-                        has_option=yes,
-                        has_option=no,)
-                if test $has_option = no; then
-                        CFLAGS="$SAVE_CFLAGS"
-                fi
-                AC_MSG_RESULT($has_option)
-                unset has_option
-                unset SAVE_CFLAGS
-        done
-        unset option
-else
-        AC_MSG_RESULT(no)
-fi
 
 #
 # Enable Debug

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: cinnamon-settings-daemon
 Section: x11
 Priority: optional
 Maintainer: Linux Mint <root@linuxmint.com>
-Build-Depends: autotools-dev,
+Build-Depends: autoconf-archive,
+               autotools-dev,
                debhelper (>= 9),
                dh-autoreconf,
                gtk-doc-tools,

--- a/plugins/a11y-keyboard/Makefile.am
+++ b/plugins/a11y-keyboard/Makefile.am
@@ -2,6 +2,8 @@ NULL =
 
 plugin_name = a11y-keyboard
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 gtkbuilderdir = $(pkgdatadir)
 gtkbuilder_DATA = 			\
 	csd-a11y-preferences-dialog.ui	\
@@ -85,6 +87,7 @@ liba11y_keyboard_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 liba11y_keyboard_la_LDFLAGS = 		\
+	$(WARN_LDFLAGS)			\
 	$(CSD_PLUGIN_LDFLAGS)		\
 	$(NULL)
 

--- a/plugins/a11y-settings/Makefile.am
+++ b/plugins/a11y-settings/Makefile.am
@@ -40,6 +40,7 @@ liba11y_settings_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 liba11y_settings_la_LDFLAGS = 		\
+	$(WARN_LDFLAGS)			\
 	$(CSD_PLUGIN_LDFLAGS)
 
 liba11y_settings_la_LIBADD  = 		\

--- a/plugins/automount/Makefile.am
+++ b/plugins/automount/Makefile.am
@@ -4,6 +4,8 @@ plugin_name = automount
 
 libexec_PROGRAMS = csd-test-automount
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 csd_test_automount_SOURCES = 		\
 	test-automount.c		\
 	csd-automount-manager.h		\
@@ -57,6 +59,7 @@ libautomount_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libautomount_la_LDFLAGS =		\
+	$(WARN_LDFLAGS)			\
 	$(CSD_PLUGIN_LDFLAGS)		\
 	$(NULL)
 

--- a/plugins/background/Makefile.am
+++ b/plugins/background/Makefile.am
@@ -4,6 +4,8 @@ plugin_name = background
 
 libexec_PROGRAMS = csd-test-background
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 csd_test_background_SOURCES =       \
     test-background.c       \
     csd-background-manager.h    \
@@ -51,6 +53,7 @@ libbackground_la_CFLAGS = \
     $(AM_CFLAGS)
 
 libbackground_la_LDFLAGS =      \
+    $(WARN_LDFLAGS)             \
     $(CSD_PLUGIN_LDFLAGS)       \
     $(NULL)
 

--- a/plugins/clipboard/Makefile.am
+++ b/plugins/clipboard/Makefile.am
@@ -2,6 +2,8 @@ NULL =
 
 plugin_name = clipboard
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 plugin_LTLIBRARIES = \
 	libclipboard.la		\
 	$(NULL)
@@ -28,6 +30,7 @@ libclipboard_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libclipboard_la_LDFLAGS = 	\
+	$(WARN_LDFLAGS)		\
 	$(CSD_PLUGIN_LDFLAGS)	\
 	$(NULL)
 

--- a/plugins/color/Makefile.am
+++ b/plugins/color/Makefile.am
@@ -3,6 +3,8 @@ plugin_name = color
 plugin_LTLIBRARIES = \
 	libcolor.la
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 libcolor_la_SOURCES = 			\
 	gcm-profile-store.c		\
 	gcm-profile-store.h		\

--- a/plugins/common/Makefile.am
+++ b/plugins/common/Makefile.am
@@ -2,6 +2,8 @@ plugin_name = common
 
 noinst_LTLIBRARIES = libcommon.la
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 libcommon_la_SOURCES = \
 	csd-keygrab.c		\
 	csd-keygrab.h		\
@@ -20,6 +22,7 @@ libcommon_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libcommon_la_LDFLAGS = \
+	$(WARN_LDFLAGS)		\
 	$(CSD_PLUGIN_LDFLAGS)
 
 libcommon_la_LIBADD  = \

--- a/plugins/cursor/Makefile.am
+++ b/plugins/cursor/Makefile.am
@@ -3,6 +3,8 @@ plugin_name = cursor
 plugin_LTLIBRARIES = \
 	libcursor.la
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 libcursor_la_SOURCES =		\
 	csd-cursor-manager.c	\
 	csd-cursor-manager.h	\
@@ -22,6 +24,7 @@ libcursor_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libcursor_la_LDFLAGS =		\
+	$(WARN_LDFLAGS)		\
 	$(CSD_PLUGIN_LDFLAGS)
 
 libcursor_la_LIBADD  =					\

--- a/plugins/datetime/Makefile.am
+++ b/plugins/datetime/Makefile.am
@@ -37,7 +37,7 @@ if HAVE_POLKIT
 BUILT_SOURCES = csd-datetime-mechanism-glue.h
 endif
 
-AM_CFLAGS = $(PLUGIN_CFLAGS) $(SETTINGS_PLUGIN_CFLAGS) $(POLKIT_CFLAGS)
+AM_CFLAGS = $(WARN_CFLAGS) $(PLUGIN_CFLAGS) $(SETTINGS_PLUGIN_CFLAGS) $(POLKIT_CFLAGS)
 csd_datetime_mechanism_LDADD = $(POLKIT_LIBS) $(SETTINGS_PLUGIN_LIBS)
 
 test_system_timezone_SOURCES = test-system-timezone.c system-timezone.c system-timezone.h

--- a/plugins/dummy/Makefile.am
+++ b/plugins/dummy/Makefile.am
@@ -3,6 +3,8 @@ plugin_name = dummy
 plugin_LTLIBRARIES = \
 	libdummy.la
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 libdummy_la_SOURCES = 		\
 	csd-dummy-manager.c	\
 	csd-dummy-manager.h	\
@@ -20,6 +22,7 @@ libdummy_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libdummy_la_LDFLAGS = 		\
+	$(WARN_CFLAGS)		\
 	$(CSD_PLUGIN_LDFLAGS)
 
 libdummy_la_LIBADD  = 		\

--- a/plugins/housekeeping/Makefile.am
+++ b/plugins/housekeeping/Makefile.am
@@ -10,6 +10,8 @@ COMMON_FILES =				\
 
 noinst_PROGRAMS = csd-disk-space-test csd-empty-trash-test
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 csd_disk_space_test_SOURCES =		\
 	csd-disk-space-test.c		\
 	$(COMMON_FILES)
@@ -51,7 +53,7 @@ libhousekeeping_la_CFLAGS = 		\
 	$(LIBNOTIFY_CFLAGS)		\
 	$(AM_CFLAGS)
 
-libhousekeeping_la_LDFLAGS = $(CSD_PLUGIN_LDFLAGS)
+libhousekeeping_la_LDFLAGS = $(WARN_LDFLAGS) $(CSD_PLUGIN_LDFLAGS)
 
 libhousekeeping_la_LIBADD = $(SETTINGS_PLUGIN_LIBS) $(GIOUNIX_LIBS) $(LIBNOTIFY_LIBS)
 

--- a/plugins/keyboard/Makefile.am
+++ b/plugins/keyboard/Makefile.am
@@ -28,6 +28,8 @@ libkeyboard_la_SOURCES = 	\
 	gkbd-configuration.h	\
 	$(NULL)
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 libkeyboard_la_CPPFLAGS = \
 	-I$(top_srcdir)/cinnamon-settings-daemon		\
 	-I$(top_srcdir)/data				\
@@ -43,6 +45,7 @@ libkeyboard_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libkeyboard_la_LDFLAGS = 	\
+	$(WARN_LDFLAGS)		\
 	$(CSD_PLUGIN_LDFLAGS)	\
 	$(NULL)
 

--- a/plugins/media-keys/Makefile.am
+++ b/plugins/media-keys/Makefile.am
@@ -6,6 +6,8 @@ plugin_name = media-keys
 NULL =
 SUBDIRS =
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 plugin_LTLIBRARIES = libmedia-keys.la
 
 BUILT_SOURCES = 			\
@@ -48,6 +50,7 @@ libmedia_keys_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libmedia_keys_la_LDFLAGS = 		\
+	$(WARN_LDFLAGS)			\
 	$(CSD_PLUGIN_LDFLAGS)
 
 libmedia_keys_la_LIBADD  = 		\

--- a/plugins/mouse/Makefile.am
+++ b/plugins/mouse/Makefile.am
@@ -2,6 +2,8 @@ plugin_name = mouse
 
 plugin_LTLIBRARIES = libmouse.la
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 libmouse_la_SOURCES = 		\
 	csd-mouse-plugin.h	\
 	csd-mouse-plugin.c	\
@@ -23,6 +25,7 @@ libmouse_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libmouse_la_LDFLAGS = 		\
+	$(WARN_LDFLAGS)		\
 	$(CSD_PLUGIN_LDFLAGS)
 
 libmouse_la_LIBADD  =							\

--- a/plugins/orientation/Makefile.am
+++ b/plugins/orientation/Makefile.am
@@ -2,6 +2,8 @@ plugin_name = orientation
 
 libexec_PROGRAMS = csd-test-orientation
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 csd_test_orientation_SOURCES =		\
 	csd-orientation-manager.h	\
 	csd-orientation-manager.c	\
@@ -45,6 +47,7 @@ liborientation_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 liborientation_la_LDFLAGS = 		\
+	$(WARN_LDFLAGS)
 	$(CSD_PLUGIN_LDFLAGS)
 
 liborientation_la_LIBADD  =						\

--- a/plugins/power/Makefile.am
+++ b/plugins/power/Makefile.am
@@ -1,5 +1,7 @@
 plugin_name = power
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 plugin_LTLIBRARIES =					\
 	libpower.la
 
@@ -32,6 +34,7 @@ libpower_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libpower_la_LDFLAGS = 					\
+	$(WARN_LDFLAGS)					\
 	$(CSD_PLUGIN_LDFLAGS)
 
 libpower_la_LIBADD  = 					\
@@ -91,6 +94,7 @@ csd_backlight_helper_LDFLAGS =				\
 	-lm
 
 csd_backlight_helper_CFLAGS =				\
+	$(WARN_CFLAGS)					\
 	$(BACKLIGHT_HELPER_CFLAGS)
 
 EXTRA_DIST += 						\

--- a/plugins/print-notifications/Makefile.am
+++ b/plugins/print-notifications/Makefile.am
@@ -1,5 +1,7 @@
 plugin_name = print-notifications
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 plugin_LTLIBRARIES = \
 	libprint-notifications.la
 
@@ -21,6 +23,7 @@ libprint_notifications_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libprint_notifications_la_LDFLAGS = 		\
+	$(WARN_LDFLAGS)				\
 	$(CSD_PLUGIN_LDFLAGS)
 
 libprint_notifications_la_LIBADD  = 		\

--- a/plugins/screensaver-proxy/Makefile.am
+++ b/plugins/screensaver-proxy/Makefile.am
@@ -1,5 +1,7 @@
 plugin_name = screensaver-proxy
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 plugin_LTLIBRARIES = libscreensaver-proxy.la
 
 libscreensaver_proxy_la_SOURCES =	\
@@ -18,7 +20,7 @@ libscreensaver_proxy_la_CFLAGS =	\
 	$(SETTINGS_PLUGIN_CFLAGS)	\
 	$(AM_CFLAGS)
 
-libscreensaver_proxy_la_LDFLAGS = $(CSD_PLUGIN_LDFLAGS)
+libscreensaver_proxy_la_LDFLAGS = $(WARN_LDFLAGS) $(CSD_PLUGIN_LDFLAGS)
 
 libscreensaver_proxy_la_LIBADD  = $(SETTINGS_PLUGIN_LIBS)
 

--- a/plugins/smartcard/Makefile.am
+++ b/plugins/smartcard/Makefile.am
@@ -1,5 +1,7 @@
 plugin_name = smartcard
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 libexec_PROGRAMS = csd-test-smartcard
 
 csd_test_smartcard_SOURCES =	\
@@ -52,6 +54,7 @@ libsmartcard_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libsmartcard_la_LDFLAGS = \
+	$(WARN_LDFLAGS)		\
 	$(CSD_PLUGIN_LDFLAGS)
 
 libsmartcard_la_LIBADD = \

--- a/plugins/sound/Makefile.am
+++ b/plugins/sound/Makefile.am
@@ -1,5 +1,7 @@
 plugin_name = sound
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 libexec_PROGRAMS = csd-test-sound
 
 csd_test_sound_SOURCES =	\
@@ -43,6 +45,7 @@ libsound_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libsound_la_LDFLAGS = \
+	$(WARN_LDFLAGS)		\
 	$(CSD_PLUGIN_LDFLAGS)
 
 libsound_la_LIBADD = \

--- a/plugins/wacom/Makefile.am
+++ b/plugins/wacom/Makefile.am
@@ -27,6 +27,7 @@ libcsdwacom_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libcsdwacom_la_LDFLAGS =		\
+	$(WARN_LDFLAGS)			\
 	$(CSD_PLUGIN_LDFLAGS)
 
 libcsdwacom_la_LIBADD  =						\
@@ -59,10 +60,12 @@ if HAVE_GUDEV
 libexec_PROGRAMS = csd-wacom-led-helper
 
 csd_wacom_led_helper_LDFLAGS =				\
+	$(WARN_LDFLAGS)					\
 	$(BACKLIGHT_HELPER_LIBS)			\
 	-lm
 
 csd_wacom_led_helper_CFLAGS =				\
+	$(WARN_CFLAGS)					\
 	$(BACKLIGHT_HELPER_CFLAGS)
 else
 libexec_PROGRAMS =

--- a/plugins/xrandr/Makefile.am
+++ b/plugins/xrandr/Makefile.am
@@ -1,5 +1,7 @@
 plugin_name = xrandr
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 icondir = $(datadir)/icons/hicolor
 context = apps
 
@@ -55,6 +57,7 @@ libxrandr_la_CFLAGS =			\
 	$(AM_CFLAGS)
 
 libxrandr_la_LDFLAGS = 			\
+	$(WARN_LDFLAGS)			\
 	$(CSD_PLUGIN_LDFLAGS)
 
 libxrandr_la_LIBADD  =					\

--- a/plugins/xsettings/Makefile.am
+++ b/plugins/xsettings/Makefile.am
@@ -2,6 +2,8 @@ NULL =
 
 plugin_name = xsettings
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 noinst_PROGRAMS = test-gtk-modules
 
 test_gtk_modules_SOURCES =	\
@@ -77,6 +79,7 @@ libxsettings_la_CFLAGS = \
 	$(AM_CFLAGS)
 
 libxsettings_la_LDFLAGS = 	\
+	$(WARN_CFLAGS)		\
 	$(CSD_PLUGIN_LDFLAGS)	\
 	$(NULL)
 


### PR DESCRIPTION
gnome-common is deprecating some vars and macros, listed here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829932

This change follows the gnome recommendations from:
https://wiki.gnome.org/Projects/GnomeCommon/Migration
