### PR TITLE
mouse: Fix critical warnings with touchpad settings

### DIFF
--- a/plugins/mouse/csd-mouse-manager.c
+++ b/plugins/mouse/csd-mouse-manager.c
@@ -1500,8 +1500,10 @@ touchpad_callback (GSettings       *settings,
                         continue;
 
                 if (g_str_equal (key, KEY_TAP_TO_CLICK)) {
+                        gboolean mouse_left_handed;
+                        mouse_left_handed = g_settings_get_boolean (manager->priv->mouse_settings, KEY_LEFT_HANDED);
                         set_tap_to_click (device, g_settings_get_boolean (settings, key),
-                                          g_settings_get_boolean (manager->priv->touchpad_settings, KEY_LEFT_HANDED));
+                                          get_touchpad_handedness (manager, mouse_left_handed));
                 }
                 else if (g_str_equal (key, KEY_TWO_FINGER_CLICK) || g_str_equal (key, KEY_THREE_FINGER_CLICK)) {
                         set_click_actions( device, g_settings_get_int (manager->priv->touchpad_settings, KEY_TWO_FINGER_CLICK), g_settings_get_int (manager->priv->touchpad_settings, KEY_THREE_FINGER_CLICK));


### PR DESCRIPTION
The code was handling touchpad "left-handed" key as a boolean, but it's an enum.

backported from:
https://git.gnome.org/browse/gnome-settings-daemon/commit/?id=e52d2c20652624d386a7ff0919dcedd04055668d