### PR TITLE
media-keys: Add Rotation lock support

### DIFF
--- a/plugins/media-keys/csd-media-keys-manager.c
+++ b/plugins/media-keys/csd-media-keys-manager.c
@@ -1333,6 +1333,22 @@ do_video_rotate_action (CsdMediaKeysManager *manager,
 }
 
 static void
+do_video_rotate_lock_action (CsdMediaKeysManager *manager,
+                             gint64               timestamp)
+{
+        GSettings *settings;
+        gboolean locked;
+
+        settings = g_settings_new ("org.cinnamon.settings-daemon.peripherals.touchscreen");
+        locked = !g_settings_get_boolean (settings, "orientation-lock");
+        g_settings_set_boolean (settings, "orientation-lock", locked);
+        g_object_unref (settings);
+
+        show_osd (manager, locked ? "rotation-locked-symbolic"
+                                  : "rotation-allowed-symbolic", NULL, -1);
+}
+
+static void
 do_toggle_accessibility_key (const char *key)
 {
         GSettings *settings;
@@ -1731,6 +1747,9 @@ do_action (CsdMediaKeysManager *manager,
                 break;
         case C_DESKTOP_MEDIA_KEY_ROTATE_VIDEO:
                 do_video_rotate_action (manager, timestamp);
+                break;
+        case C_DESKTOP_MEDIA_KEY_ROTATE_VIDEO_LOCK:
+                do_video_rotate_lock_action (manager, timestamp);
                 break;
         case C_DESKTOP_MEDIA_KEY_SCREENREADER:
                 do_screenreader_action (manager);


### PR DESCRIPTION
Based on

https://github.com/GNOME/gnome-settings-daemon/commit/76b548e3dd4c52455e9c2684d2e64e41b9c5cd84

needs this commit to compile

https://github.com/linuxmint/cinnamon-desktop/pull/83