### PR TITLE
Fix redundant redeclarations

### DIFF
--- a/plugins/a11y-keyboard/csd-a11y-keyboard-manager.c
+++ b/plugins/a11y-keyboard/csd-a11y-keyboard-manager.c
@@ -69,8 +69,6 @@ struct CsdA11yKeyboardManagerPrivate
         NotifyNotification *notification;
 };
 
-static void     csd_a11y_keyboard_manager_class_init  (CsdA11yKeyboardManagerClass *klass);
-static void     csd_a11y_keyboard_manager_init        (CsdA11yKeyboardManager      *a11y_keyboard_manager);
 static void     csd_a11y_keyboard_manager_finalize    (GObject             *object);
 static void     csd_a11y_keyboard_manager_ensure_status_icon (CsdA11yKeyboardManager *manager);
 static void     set_server_from_gsettings (CsdA11yKeyboardManager *manager);

--- a/plugins/a11y-keyboard/csd-a11y-preferences-dialog.c
+++ b/plugins/a11y-keyboard/csd-a11y-preferences-dialog.c
@@ -79,8 +79,6 @@ enum {
         PROP_0,
 };
 
-static void     csd_a11y_preferences_dialog_class_init  (CsdA11yPreferencesDialogClass *klass);
-static void     csd_a11y_preferences_dialog_init        (CsdA11yPreferencesDialog      *a11y_preferences_dialog);
 static void     csd_a11y_preferences_dialog_finalize    (GObject                       *object);
 
 G_DEFINE_TYPE (CsdA11yPreferencesDialog, csd_a11y_preferences_dialog, GTK_TYPE_DIALOG)

--- a/plugins/automount/csd-automount-manager.c
+++ b/plugins/automount/csd-automount-manager.c
@@ -51,8 +51,6 @@ struct CsdAutomountManagerPrivate
         GList *volume_queue;
 };
 
-static void     csd_automount_manager_class_init  (CsdAutomountManagerClass *klass);
-static void     csd_automount_manager_init        (CsdAutomountManager      *csd_automount_manager);
 
 G_DEFINE_TYPE (CsdAutomountManager, csd_automount_manager, G_TYPE_OBJECT)
 

--- a/plugins/background/csd-background-manager.c
+++ b/plugins/background/csd-background-manager.c
@@ -58,8 +58,6 @@ struct CsdBackgroundManagerPrivate
         guint        proxy_signal_id;
 };
 
-static void     csd_background_manager_class_init  (CsdBackgroundManagerClass *klass);
-static void     csd_background_manager_init        (CsdBackgroundManager      *background_manager);
 static void     csd_background_manager_finalize    (GObject             *object);
 
 static void setup_bg (CsdBackgroundManager *manager);

--- a/plugins/clipboard/csd-clipboard-manager.c
+++ b/plugins/clipboard/csd-clipboard-manager.c
@@ -83,8 +83,6 @@ typedef struct
         int         offset;
 } IncrConversion;
 
-static void     csd_clipboard_manager_class_init  (CsdClipboardManagerClass *klass);
-static void     csd_clipboard_manager_init        (CsdClipboardManager      *clipboard_manager);
 static void     csd_clipboard_manager_finalize    (GObject                  *object);
 
 static void     clipboard_manager_watch_cb        (CsdClipboardManager *manager,

--- a/plugins/color/csd-color-manager.c
+++ b/plugins/color/csd-color-manager.c
@@ -63,8 +63,6 @@ enum {
         PROP_0,
 };
 
-static void     csd_color_manager_class_init  (CsdColorManagerClass *klass);
-static void     csd_color_manager_init        (CsdColorManager      *color_manager);
 static void     csd_color_manager_finalize    (GObject             *object);
 
 G_DEFINE_TYPE (CsdColorManager, csd_color_manager, G_TYPE_OBJECT)

--- a/plugins/cursor/csd-cursor-manager.c
+++ b/plugins/cursor/csd-cursor-manager.c
@@ -58,8 +58,6 @@ enum {
         PROP_0,
 };
 
-static void     csd_cursor_manager_class_init  (CsdCursorManagerClass *klass);
-static void     csd_cursor_manager_init        (CsdCursorManager      *cursor_manager);
 static void     csd_cursor_manager_finalize    (GObject               *object);
 
 G_DEFINE_TYPE (CsdCursorManager, csd_cursor_manager, G_TYPE_OBJECT)

--- a/plugins/dummy/csd-dummy-manager.c
+++ b/plugins/dummy/csd-dummy-manager.c
@@ -50,8 +50,6 @@ enum {
         PROP_0,
 };
 
-static void     csd_dummy_manager_class_init  (CsdDummyManagerClass *klass);
-static void     csd_dummy_manager_init        (CsdDummyManager      *dummy_manager);
 static void     csd_dummy_manager_finalize    (GObject             *object);
 
 G_DEFINE_TYPE (CsdDummyManager, csd_dummy_manager, G_TYPE_OBJECT)

--- a/plugins/housekeeping/csd-housekeeping-manager.c
+++ b/plugins/housekeeping/csd-housekeeping-manager.c
@@ -47,9 +47,6 @@ struct CsdHousekeepingManagerPrivate {
 
 #define CSD_HOUSEKEEPING_MANAGER_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), CSD_TYPE_HOUSEKEEPING_MANAGER, CsdHousekeepingManagerPrivate))
 
-static void     csd_housekeeping_manager_class_init  (CsdHousekeepingManagerClass *klass);
-static void     csd_housekeeping_manager_init        (CsdHousekeepingManager      *housekeeping_manager);
-
 G_DEFINE_TYPE (CsdHousekeepingManager, csd_housekeeping_manager, G_TYPE_OBJECT)
 
 static gpointer manager_object = NULL;

--- a/plugins/housekeeping/csd-ldsm-dialog.c
+++ b/plugins/housekeeping/csd-ldsm-dialog.c
@@ -52,9 +52,6 @@ struct CsdLdsmDialogPrivate
 
 #define CSD_LDSM_DIALOG_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), CSD_TYPE_LDSM_DIALOG, CsdLdsmDialogPrivate))
 
-static void     csd_ldsm_dialog_class_init  (CsdLdsmDialogClass *klass);
-static void     csd_ldsm_dialog_init        (CsdLdsmDialog      *dialog);
-
 G_DEFINE_TYPE (CsdLdsmDialog, csd_ldsm_dialog, GTK_TYPE_DIALOG);
 
 static const gchar*

--- a/plugins/keyboard/csd-keyboard-manager.c
+++ b/plugins/keyboard/csd-keyboard-manager.c
@@ -76,8 +76,6 @@ struct CsdKeyboardManagerPrivate
         CsdNumLockState old_state;
 };
 
-static void     csd_keyboard_manager_class_init  (CsdKeyboardManagerClass *klass);
-static void     csd_keyboard_manager_init        (CsdKeyboardManager      *keyboard_manager);
 static void     csd_keyboard_manager_finalize    (GObject                 *object);
 
 G_DEFINE_TYPE (CsdKeyboardManager, csd_keyboard_manager, G_TYPE_OBJECT)

--- a/plugins/media-keys/csd-media-keys-manager.c
+++ b/plugins/media-keys/csd-media-keys-manager.c
@@ -195,8 +195,6 @@ struct CsdMediaKeysManagerPrivate
         NotifyNotification *kb_backlight_notification;
 };
 
-static void     csd_media_keys_manager_class_init  (CsdMediaKeysManagerClass *klass);
-static void     csd_media_keys_manager_init        (CsdMediaKeysManager      *media_keys_manager);
 static void     csd_media_keys_manager_finalize    (GObject                  *object);
 static void     register_manager                   (CsdMediaKeysManager      *manager);
 static gboolean do_action (CsdMediaKeysManager *manager,

--- a/plugins/mouse/csd-mouse-manager.c
+++ b/plugins/mouse/csd-mouse-manager.c
@@ -100,8 +100,6 @@ struct CsdMouseManagerPrivate
         GPid locate_pointer_pid;
 };
 
-static void     csd_mouse_manager_class_init  (CsdMouseManagerClass *klass);
-static void     csd_mouse_manager_init        (CsdMouseManager      *mouse_manager);
 static void     csd_mouse_manager_finalize    (GObject             *object);
 static void     set_tap_to_click              (GdkDevice           *device,
                                                gboolean             state,

--- a/plugins/orientation/csd-orientation-manager.c
+++ b/plugins/orientation/csd-orientation-manager.c
@@ -70,8 +70,6 @@ struct CsdOrientationManagerPrivate
 #define CSD_DBUS_PATH "/org/cinnamon/SettingsDaemon"
 #define CSD_DBUS_BASE_INTERFACE "org.cinnamon.SettingsDaemon"
 
-static void     csd_orientation_manager_class_init  (CsdOrientationManagerClass *klass);
-static void     csd_orientation_manager_init        (CsdOrientationManager      *orientation_manager);
 static void     csd_orientation_manager_finalize    (GObject                    *object);
 
 G_DEFINE_TYPE (CsdOrientationManager, csd_orientation_manager, G_TYPE_OBJECT)

--- a/plugins/power/csd-power-manager.c
+++ b/plugins/power/csd-power-manager.c
@@ -241,8 +241,6 @@ enum {
         PROP_0,
 };
 
-static void     csd_power_manager_class_init  (CsdPowerManagerClass *klass);
-static void     csd_power_manager_init        (CsdPowerManager      *power_manager);
 static void     csd_power_manager_finalize    (GObject              *object);
 
 static UpDevice *engine_get_composite_device (CsdPowerManager *manager, UpDevice *original_device);

--- a/plugins/print-notifications/csd-print-notifications-manager.c
+++ b/plugins/print-notifications/csd-print-notifications-manager.c
@@ -81,8 +81,6 @@ enum {
         PROP_0,
 };
 
-static void     csd_print_notifications_manager_class_init  (CsdPrintNotificationsManagerClass *klass);
-static void     csd_print_notifications_manager_init        (CsdPrintNotificationsManager      *print_notifications_manager);
 static void     csd_print_notifications_manager_finalize    (GObject                           *object);
 static gboolean cups_connection_test                        (gpointer                           user_data);
 

--- a/plugins/screensaver-proxy/csd-screensaver-proxy-manager.c
+++ b/plugins/screensaver-proxy/csd-screensaver-proxy-manager.c
@@ -145,8 +145,6 @@ struct CsdScreensaverProxyManagerPrivate
         GHashTable              *cookie_ht; /* key = cookie, value = sender */
 };
 
-static void     csd_screensaver_proxy_manager_class_init  (CsdScreensaverProxyManagerClass *klass);
-static void     csd_screensaver_proxy_manager_init        (CsdScreensaverProxyManager      *screensaver_proxy_manager);
 static void     csd_screensaver_proxy_manager_finalize    (GObject             *object);
 
 G_DEFINE_TYPE (CsdScreensaverProxyManager, csd_screensaver_proxy_manager, G_TYPE_OBJECT)

--- a/plugins/sound/csd-sound-manager.c
+++ b/plugins/sound/csd-sound-manager.c
@@ -94,8 +94,6 @@ struct CsdSoundManagerPrivate
         GList *onetime_sounds;
 };
 
-static void csd_sound_manager_class_init (CsdSoundManagerClass *klass);
-static void csd_sound_manager_init (CsdSoundManager *sound_manager);
 static void csd_sound_manager_finalize (GObject *object);
 
 G_DEFINE_TYPE (CsdSoundManager, csd_sound_manager, G_TYPE_OBJECT)

--- a/plugins/xrandr/csd-xrandr-manager.c
+++ b/plugins/xrandr/csd-xrandr-manager.c
@@ -136,8 +136,6 @@ static const GnomeRRRotation possible_rotations[] = {
         /* We don't allow REFLECT_X or REFLECT_Y for now, as gnome-display-properties doesn't allow them, either */
 };
 
-static void     csd_xrandr_manager_class_init  (CsdXrandrManagerClass *klass);
-static void     csd_xrandr_manager_init        (CsdXrandrManager      *xrandr_manager);
 static void     csd_xrandr_manager_finalize    (GObject             *object);
 
 static void error_message (CsdXrandrManager *mgr, const char *primary_text, GError *error_to_display, const char *secondary_text);

--- a/plugins/xsettings/csd-xsettings-manager.c
+++ b/plugins/xsettings/csd-xsettings-manager.c
@@ -261,8 +261,6 @@ enum {
         CSD_XSETTINGS_ERROR_INIT
 };
 
-static void     cinnamon_xsettings_manager_class_init  (CinnamonSettingsXSettingsManagerClass *klass);
-static void     cinnamon_xsettings_manager_init        (CinnamonSettingsXSettingsManager      *xsettings_manager);
 static void     cinnamon_xsettings_manager_finalize    (GObject                  *object);
 
 G_DEFINE_TYPE (CinnamonSettingsXSettingsManager, cinnamon_xsettings_manager, G_TYPE_OBJECT)


### PR DESCRIPTION
Fixes 70 warnings similar to

```
In file included from /usr/include/glib-2.0/gobject/gobject.h:24:0,
                 from /usr/include/glib-2.0/gobject/gbinding.h:29,
                 from /usr/include/glib-2.0/glib-object.h:23,
                 from cinnamon-settings-manager.c:30:
cinnamon-settings-manager.c:76:41: warning: redundant redeclaration of 'cinnamon_settings_manager_init' [-Wredundant-decls]
 G_DEFINE_TYPE (CinnamonSettingsManager, cinnamon_settings_manager, G_TYPE_OBJECT)
                                         ^
/usr/include/glib-2.0/gobject/gtype.h:1943:17: note: in definition of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN'
 static void     type_name##_init              (TypeName        *self); \
                 ^~~~~~~~~
/usr/include/glib-2.0/gobject/gtype.h:1590:43: note: in expansion of macro 'G_DEFINE_TYPE_EXTENDED'
 #define G_DEFINE_TYPE(TN, t_n, T_P)       G_DEFINE_TYPE_EXTENDED (TN, t_n, T_P, 0, {})
                                           ^~~~~~~~~~~~~~~~~~~~~~
cinnamon-settings-manager.c:76:1: note: in expansion of macro 'G_DEFINE_TYPE'
 G_DEFINE_TYPE (CinnamonSettingsManager, cinnamon_settings_manager, G_TYPE_OBJECT)
 ^~~~~~~~~~~~~
cinnamon-settings-manager.c:73:17: note: previous declaration of 'cinnamon_settings_manager_init' was here
 static void     cinnamon_settings_manager_init        (CinnamonSettingsManager      *settings_manager);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/glib-2.0/gobject/gobject.h:24:0,
                 from /usr/include/glib-2.0/gobject/gbinding.h:29,
                 from /usr/include/glib-2.0/glib-object.h:23,
                 from cinnamon-settings-manager.c:30:
cinnamon-settings-manager.c:76:41: warning: redundant redeclaration of 'cinnamon_settings_manager_class_init' [-Wredundant-decls]
 G_DEFINE_TYPE (CinnamonSettingsManager, cinnamon_settings_manager, G_TYPE_OBJECT)
                                         ^
/usr/include/glib-2.0/gobject/gtype.h:1944:17: note: in definition of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN'
 static void     type_name##_class_init        (TypeName##Class *klass); \
                 ^~~~~~~~~
/usr/include/glib-2.0/gobject/gtype.h:1590:43: note: in expansion of macro 'G_DEFINE_TYPE_EXTENDED'
 #define G_DEFINE_TYPE(TN, t_n, T_P)       G_DEFINE_TYPE_EXTENDED (TN, t_n, T_P, 0, {})
                                           ^~~~~~~~~~~~~~~~~~~~~~
cinnamon-settings-manager.c:76:1: note: in expansion of macro 'G_DEFINE_TYPE'
 G_DEFINE_TYPE (CinnamonSettingsManager, cinnamon_settings_manager, G_TYPE_OBJECT)
 ^~~~~~~~~~~~~
cinnamon-settings-manager.c:72:17: note: previous declaration of 'cinnamon_settings_manager_class_init' was here
 static void     cinnamon_settings_manager_class_init  (CinnamonSettingsManagerClass *klass);
```