### PR TITLE
test-plugin.h: Stop using deprecated GSettings API

### DIFF
--- a/plugins/datetime/csd-datetime-mechanism-main.c
+++ b/plugins/datetime/csd-datetime-mechanism-main.c
@@ -134,7 +134,6 @@ main (int argc, char **argv)
                 g_thread_init (NULL);
         }
         dbus_g_thread_init ();
-        g_type_init ();
 
         connection = get_system_bus ();
         if (connection == NULL) {

--- a/plugins/datetime/test-system-timezone.c
+++ b/plugins/datetime/test-system-timezone.c
@@ -66,7 +66,6 @@ main (int    argc,
 
 	retval = 0;
 
-	g_type_init ();
 
 	context = g_option_context_new ("");
 	g_option_context_add_main_entries (context, options, NULL);

--- a/plugins/power/csd-backlight-helper.c
+++ b/plugins/power/csd-backlight-helper.c
@@ -154,8 +154,6 @@ main (int argc, char *argv[])
 		{ NULL}
 	};
 
-	/* setup type system */
-	g_type_init ();
 
 	context = g_option_context_new (NULL);
 	g_option_context_set_summary (context, "Cinnamon Settings Daemon Backlight Helper");

--- a/plugins/print-notifications/csd-printer.c
+++ b/plugins/print-notifications/csd-printer.c
@@ -1322,7 +1322,6 @@ main (int argc, char *argv[])
   npn_owner_id = 0;
   pdi_owner_id = 0;
 
-  g_type_init ();
 
   notify_init ("cinnamon-settings-daemon-printer");
 

--- a/plugins/smartcard/csd-smartcard-manager.c
+++ b/plugins/smartcard/csd-smartcard-manager.c
@@ -1484,7 +1484,6 @@ main (int   argc,
         g_log_set_always_fatal (G_LOG_LEVEL_ERROR
                                 | G_LOG_LEVEL_CRITICAL | G_LOG_LEVEL_WARNING);
 
-        g_type_init ();
 
         g_message ("creating instance of 'smartcard manager' object...");
         manager = csd_smartcard_manager_new (NULL);

--- a/plugins/xsettings/fontconfig-monitor.c
+++ b/plugins/xsettings/fontconfig-monitor.c
@@ -183,7 +183,6 @@ main (void)
 {
         GMainLoop *loop;
 
-        g_type_init ();
 
         fontconfig_monitor_start ((GFunc) yay, NULL);
 

--- a/plugins/xsettings/test-gtk-modules.c
+++ b/plugins/xsettings/test-gtk-modules.c
@@ -18,7 +18,6 @@ int main (int argc, char **argv)
 	GMainLoop *loop;
 	CsdXSettingsGtk *gtk;
 
-	g_type_init ();
 
 	gtk = csd_xsettings_gtk_new ();
         g_signal_connect (G_OBJECT (gtk), "notify::gtk-modules",


### PR DESCRIPTION
Based on https://git.gnome.org/browse/gnome-settings-daemon/commit/?id=044c471fae836e9c545e49eeed82bf3e05de664f