### PR TITLE
remove deprecated g_thread_init

### DIFF
--- a/plugins/datetime/csd-datetime-mechanism-main.c
+++ b/plugins/datetime/csd-datetime-mechanism-main.c
@@ -130,9 +130,6 @@ main (int argc, char **argv)
 
         ret = 1;
 
-        if (! g_thread_supported ()) {
-                g_thread_init (NULL);
-        }
         dbus_g_thread_init ();
 
         connection = get_system_bus ();


### PR DESCRIPTION
fixes

```
csd-datetime-mechanism-main.c:134:17: warning: 'g_thread_init' is deprecated [-Wdeprecated-declarations]
                 g_thread_init (NULL);
```