### PR TITLE
csd-clipboard-manager: remove compiler warnings

### DIFF
--- a/plugins/clipboard/csd-clipboard-manager.c
+++ b/plugins/clipboard/csd-clipboard-manager.c
@@ -67,7 +67,7 @@ struct CsdClipboardManagerPrivate
 typedef struct
 {
         unsigned char *data;
-        int            length;
+        unsigned long  length;
         Atom           target;
         Atom           type;
         int            format;
@@ -472,17 +472,17 @@ convert_clipboard_manager (CsdClipboardManager *manager,
                 finish_selection_request (manager, xev, True);
         } else if (xev->xselectionrequest.target == XA_TARGETS) {
                 int  n_targets = 0;
-                Atom targets[3];
+                Atom tgets[3];
 
-                targets[n_targets++] = XA_TARGETS;
-                targets[n_targets++] = XA_TIMESTAMP;
-                targets[n_targets++] = XA_SAVE_TARGETS;
+                tgets[n_targets++] = XA_TARGETS;
+                tgets[n_targets++] = XA_TIMESTAMP;
+                tgets[n_targets++] = XA_SAVE_TARGETS;
 
                 XChangeProperty (manager->priv->display,
                                  xev->xselectionrequest.requestor,
                                  xev->xselectionrequest.property,
                                  XA_ATOM, 32, PropModeReplace,
-                                 (unsigned char *) targets, n_targets);
+                                 (unsigned char *) tgets, n_targets);
 
                 finish_selection_request (manager, xev, True);
         } else
@@ -594,9 +594,8 @@ convert_clipboard (CsdClipboardManager *manager,
         List           *conversions;
         IncrConversion *rdata;
         Atom            type;
-        int             i;
         int             format;
-        unsigned long   nitems;
+        unsigned long   i, nitems;
         unsigned long   remaining;
         Atom           *multiple;
 


### PR DESCRIPTION
There was actually a potential error here, the variables used for the clipboard max were larger than
those used to handle internal loops, so very large copies could have failed
if the maximum sizes were set very high.  There was also some very confusing variable
shadowing at one place.