### PR TITLE
media-keys: Don't show the level in the screen lock OSD

### DIFF
--- a/plugins/media-keys/csd-media-keys-manager.c
+++ b/plugins/media-keys/csd-media-keys-manager.c
@@ -1340,7 +1340,7 @@ do_video_rotate_lock_action (CsdMediaKeysManager *manager,
         g_object_unref (settings);
 
         show_osd (manager, locked ? "rotation-locked-symbolic"
-                                  : "rotation-allowed-symbolic", NULL, -1);
+                                  : "rotation-allowed-symbolic", -1, OSD_ALL_OUTPUTS);
 }
 
 static void


### PR DESCRIPTION
When support was added to show this OSD the wrong values were being passed which
results in the a level bar showing in the OSD. Fix the values so we don't see it
anymore.