### PR TITLE
xrandr: explicitly set clone state variable when generating monitor configs

### DIFF
--- a/plugins/xrandr/csd-xrandr-manager.c
+++ b/plugins/xrandr/csd-xrandr-manager.c
@@ -919,6 +919,8 @@ make_clone_setup (CsdXrandrManager *manager, GnomeRRScreen *screen)
                 result = NULL;
         }
 
+        gnome_rr_config_set_clone (result, TRUE);
+
         print_configuration (result, "clone setup");
 
         return result;
@@ -1020,6 +1022,8 @@ make_laptop_setup (CsdXrandrManager *manager, GnomeRRScreen *screen)
                 g_object_unref (G_OBJECT (result));
                 result = NULL;
         }
+
+        gnome_rr_config_set_clone (result, FALSE);
 
         print_configuration (result, "Laptop setup");
 
@@ -1162,6 +1166,8 @@ make_xinerama_setup (CsdXrandrManager *manager, GnomeRRScreen *screen)
                 result = NULL;
         }
 
+        gnome_rr_config_set_clone (result, FALSE);
+
         print_configuration (result, "xinerama setup");
 
         return result;
@@ -1196,6 +1202,8 @@ make_other_setup (GnomeRRScreen *screen)
                 g_object_unref (G_OBJECT (result));
                 result = NULL;
         }
+
+        gnome_rr_config_set_clone (result, FALSE);
 
         print_configuration (result, "other setup");
 


### PR DESCRIPTION
Based on https://git.gnome.org/browse/gnome-settings-daemon/commit/?id=5f7643800a8bc26bd2835dc9a3df085bf0fab422


Each potential monitor configuration that can be cycled through with fn-f7 on laptops is generated by copying and tweaking the current monitor configuration. One necessary, but neglected tweak, was the current "clone" state. This means the clone state of the current configuration leaks into every other config. Users who start in a cloned mode can never leave a clone with the hotkey. This commit explicitly sets the clone state appropriately. Patch based on valuable, and detailed feedback provided by Marico Xu.

https://bugzilla.gnome.org/show_bug.cgi?id=677472