### PR TITLE
Revert "xrandr: explicitly set clone state variable when generating m…

### DIFF
--- a/plugins/xrandr/csd-xrandr-manager.c
+++ b/plugins/xrandr/csd-xrandr-manager.c
@@ -919,8 +919,6 @@ make_clone_setup (CsdXrandrManager *manager, GnomeRRScreen *screen)
                 result = NULL;
         }
 
-        gnome_rr_config_set_clone (result, TRUE);
-
         print_configuration (result, "clone setup");
 
         return result;
@@ -1022,8 +1020,6 @@ make_laptop_setup (CsdXrandrManager *manager, GnomeRRScreen *screen)
                 g_object_unref (G_OBJECT (result));
                 result = NULL;
         }
-
-        gnome_rr_config_set_clone (result, FALSE);
 
         print_configuration (result, "Laptop setup");
 
@@ -1166,8 +1162,6 @@ make_xinerama_setup (CsdXrandrManager *manager, GnomeRRScreen *screen)
                 result = NULL;
         }
 
-        gnome_rr_config_set_clone (result, FALSE);
-
         print_configuration (result, "xinerama setup");
 
         return result;
@@ -1202,8 +1196,6 @@ make_other_setup (GnomeRRScreen *screen)
                 g_object_unref (G_OBJECT (result));
                 result = NULL;
         }
-
-        gnome_rr_config_set_clone (result, FALSE);
 
         print_configuration (result, "other setup");
 


### PR DESCRIPTION
…onitor configs"

This reverts commit fdb2ceebd5efed0726afb17fc7d0b182328a58a5.

This had already been added

https://github.com/linuxmint/cinnamon-settings-daemon/commit/ea85ec938d8602bc0ea58bc36f0136c078a90ccf

then moved

https://github.com/linuxmint/cinnamon-settings-daemon/commit/88523068a210d8862484b264739ed1be6a8aa0d8