### PR TITLE
csd-xsettings-gtk: Avoid a potential GFile leak

### DIFF
--- a/plugins/xsettings/csd-xsettings-gtk.c
+++ b/plugins/xsettings/csd-xsettings-gtk.c
@@ -198,12 +198,13 @@ get_gtk_modules_from_dir (CsdXSettingsGtk *gtk)
 
                         gtk->priv->dir_modules = ht;
                 }
-                g_object_unref (info);
         } else {
                 empty_cond_settings_list (gtk);
         }
 
 bail:
+        if (info != NULL)
+                g_object_unref (info);
         g_object_unref (file);
 }
 


### PR DESCRIPTION
If the GTK MODULES DIRECTORY does not open then a GFile would leak, this avoids that.