### PR TITLE
housekeeping: Fix deprecated GUnixMountMonitor calls

### DIFF
--- a/plugins/housekeeping/csd-disk-space.c
+++ b/plugins/housekeeping/csd-disk-space.c
@@ -600,7 +600,7 @@ ldsm_check_all_mounts (gpointer data)
                         continue;
                 }
 
-                if (ldsm_mount_is_user_ignore (g_unix_mount_get_mount_path (mount))) {
+                if (ldsm_mount_is_user_ignore (path)) {
                         ldsm_free_mount_info (mount_info);
                         continue;
                 }

--- a/plugins/housekeeping/csd-disk-space.c
+++ b/plugins/housekeeping/csd-disk-space.c
@@ -445,7 +445,7 @@ ldsm_mount_has_space (LdsmMountInfo *mount)
         /* enough free space, nothing to do */
         if (free_space > free_percent_notify)
                 return TRUE;
-                
+
         if (((gint64) mount->buf.f_frsize * (gint64) mount->buf.f_bavail) > ((gint64) free_size_gb_no_notify * GIGABYTE))
                 return TRUE;
 
@@ -478,7 +478,7 @@ ldsm_mount_is_user_ignore (const gchar *path)
                 return TRUE;
         else
                 return FALSE;
-}                
+}
 
 
 static void
@@ -775,8 +775,7 @@ csd_ldsm_setup (gboolean check_now)
         g_signal_connect (G_OBJECT (settings), "changed",
                           G_CALLBACK (csd_ldsm_update_config), NULL);
 
-        ldsm_monitor = g_unix_mount_monitor_new ();
-        g_unix_mount_monitor_set_rate_limit (ldsm_monitor, 1000);
+        ldsm_monitor = g_unix_mount_monitor_get ();
         g_signal_connect (ldsm_monitor, "mounts-changed",
                           G_CALLBACK (ldsm_mounts_changed), NULL);
 
@@ -793,7 +792,7 @@ csd_ldsm_clean (void)
         if (ldsm_timeout_id) {
             g_source_remove (ldsm_timeout_id);
             ldsm_timeout_id = 0;
-        }        
+        }
 
         if (ldsm_notified_hash)
                 g_hash_table_destroy (ldsm_notified_hash);


### PR DESCRIPTION
https://github.com/GNOME/gnome-settings-daemon/commit/a7b82826bd716e50fae6668561117dfedc8873ec#diff-35dd745f84c1c68f9626401cda5ee45d

and one more minor removal of a duplicated call