### PR TITLE
Add an option to prevent handle-lid-switch from being inhibited. 

### DIFF
--- a/data/org.cinnamon.settings-daemon.plugins.power.gschema.xml.in.in
+++ b/data/org.cinnamon.settings-daemon.plugins.power.gschema.xml.in.in
@@ -146,5 +146,10 @@
 	This can be useful for working around systems with broken default backlight control behavior which provide
 	multiple interfaces. If you are having problems, try setting 'raw' to a higher priority.</_description>
     </key>
+    <key name="inhibit-lid-switch-enabled" type="b">
+      <default>true</default>
+      <_summary>Whether or not cinnamon-settings-daemon inhibits logind's handling of lid switch</_summary>
+      <_description>If set to false, you should not rely on Cinnamon's lid actions and use the logind ones instead</_description>
+    </key>
   </schema>
 </schemalist>

--- a/plugins/power/csd-power-manager.c
+++ b/plugins/power/csd-power-manager.c
@@ -229,6 +229,7 @@ struct CsdPowerManagerPrivate
 
         /* logind stuff */
         GDBusProxy              *logind_proxy;
+        gboolean                 inhibit_lid_switch_enabled;
         gint                     inhibit_lid_switch_fd;
         gboolean                 inhibit_lid_switch_taken;
         gint                     inhibit_suspend_fd;
@@ -3888,6 +3889,13 @@ inhibit_lid_switch_done (GObject      *source,
 static void
 inhibit_lid_switch (CsdPowerManager *manager)
 {
+        if (!manager->priv->inhibit_lid_switch_enabled)  {
+                // The users asks us not to interfere with what logind does
+                // w.r.t. handling the lid switch
+                g_debug ("inhibiting lid-switch disabled");
+                return;
+        }
+
         GVariant *params;
 
         if (manager->priv->inhibit_lid_switch_taken) {
@@ -4194,6 +4202,8 @@ csd_power_manager_start (CsdPowerManager *manager,
         manager->priv->settings_xrandr = g_settings_new (CSD_XRANDR_SETTINGS_SCHEMA);
         manager->priv->settings_session = g_settings_new (CSD_SESSION_SETTINGS_SCHEMA);
         manager->priv->use_logind = g_settings_get_boolean (manager->priv->settings_session, "settings-daemon-uses-logind");
+        manager->priv->inhibit_lid_switch_enabled =
+                          g_settings_get_boolean (manager->priv->settings_session, "inhibit-lid-switch-enabled");
 
         manager->priv->up_client = up_client_new ();
 #if ! UP_CHECK_VERSION(0,99,0)


### PR DESCRIPTION
Closes #141.
Depends on https://github.com/linuxmint/cinnamon-desktop/pull/105