### PR TITLE
Update gnome-power-manager's stats desktop name

### DIFF
--- a/plugins/media-keys/csd-media-keys-manager.c
+++ b/plugins/media-keys/csd-media-keys-manager.c
@@ -1783,7 +1783,7 @@ do_action (CsdMediaKeysManager *manager,
                 do_keyboard_brightness_action (manager, type);
                 break;
         case C_DESKTOP_MEDIA_KEY_BATTERY:
-                do_execute_desktop (manager, "gnome-power-statistics.desktop", timestamp);
+                do_execute_desktop (manager, "org.gnome.PowerStats.desktop", timestamp);
                 break;
         /* Note, no default so compiler catches missing keys */
         case C_DESKTOP_MEDIA_KEY_SEPARATOR:


### PR DESCRIPTION
It appears that cinnamon-settings-daemon tries to run
gnome-power-statistics via its .desktop file. However, it is using the
old .desktop filename, gnome-power-statistics.desktop, which changed
to org.gnome.PowerStats in GNOME 3.22; so I don't think this has worked
since before stretch.

This was originally reported to the Debian bug tracker[1] by Simon McVittie

[1]: https://bugs.debian.org/895481