### PR TITLE
fix build with glib 2.57.2

### DIFF
--- a/plugins/housekeeping/csd-disk-space.c
+++ b/plugins/housekeeping/csd-disk-space.c
@@ -796,7 +796,8 @@ csd_ldsm_clean (void)
         g_clear_object (&ldsm_monitor);
         g_clear_object (&settings);
         g_clear_object (&dialog);
-        g_clear_pointer (&notification, notify_notification_close);
+        if (notification != NULL)
+                notify_notification_close (notification, NULL);
         g_slist_free_full (ignore_paths, g_free);
         ignore_paths = NULL;
 }


### PR DESCRIPTION
This fixes the build with glib 2.57.2 (as seen in Ubuntu 18.10 "cosmic). See https://bugs.debian.org/905657

The build still works with glib 2.56 as tested with Debian unstable.

Commit message
----------------------
notify_notification_close() expects that a parameter will be available for
the error location, which could be a dangling pointer in a register or
on the stack in the case of some architectures.

This was caught by GNOME/glib#1425 which allows us to check proper type
parameters.

Cherry-picked to cinnamon-settings-daemon from
https://gitlab.gnome.org/GNOME/gnome-settings-daemon/commit/3110457f