### PR TITLE
csd-media-keys-manager.c: Honor default calculator application schema

### DIFF
--- a/plugins/media-keys/csd-media-keys-manager.c
+++ b/plugins/media-keys/csd-media-keys-manager.c
@@ -526,6 +526,22 @@ do_terminal_action (CsdMediaKeysManager *manager)
 }
 
 static void
+do_calculator_action (CsdMediaKeysManager *manager)
+{
+        GSettings *settings;
+        char *calc;
+
+        settings = g_settings_new ("org.cinnamon.desktop.default-applications.calculator");
+        calc = g_settings_get_string (settings, "exec");
+
+        if (calc)
+        execute (manager, calc, FALSE);
+
+        g_free (calc);
+        g_object_unref (settings);
+}
+
+static void
 cinnamon_session_shutdown (CsdMediaKeysManager *manager)
 {
 	GError *error = NULL;
@@ -1718,15 +1734,7 @@ do_action (CsdMediaKeysManager *manager,
                 do_media_action (manager, timestamp);
                 break;
         case C_DESKTOP_MEDIA_KEY_CALCULATOR:
-                if ((cmd = g_find_program_in_path ("gnome-calculator"))) {
-                execute (manager, "gnome-calculator", FALSE);
-                } else if ((cmd = g_find_program_in_path ("galculator"))) {
-                execute (manager, "galculator", FALSE);
-                } else {
-                execute (manager, "mate-calc", FALSE);
-                }
-
-                g_free (cmd);
+		do_calculator_action (manager);
                 break;
         case C_DESKTOP_MEDIA_KEY_PLAY:
                 return do_multimedia_player_action (manager, NULL, "Play");


### PR DESCRIPTION
* Removes if-elif-else ladder that determines which calculator application to open when XF86Calculator is pressed
* Instead, when XF86Calculator is pressed, CSD executes the command listed in the default calculator application schema (defined in commit [5b9ca20](https://github.com/linuxmint/cinnamon-desktop/commit/5b9ca2075dcfa9a23bdc9542cac90e6fc7252086) for [linuxmint/cinnamon-desktop](https://github.com/linuxmint/cinnamon-desktop))
* In order to function properly, this PR is dependent on the merger of commit 5b9ca20 into [linuxmint/cinnamon-desktop:master](https://github.com/linuxmint/cinnamon-desktop/tree/master) to define the schema
* I highly recommend merging commit [7879ac2](https://github.com/linuxmint/Cinnamon/commit/7879ac2dceeaeb6560e9277b1546154fb29b0b3d) into [linuxmint/Cinnamon:master](https://github.com/linuxmint/Cinnamon/tree/master) to provide a user-friendly method to change the default calculator application schema, namely by adding a SettingsWidget() to Preferred Applications
* Relevant PRs
  1. https://github.com/linuxmint/cinnamon-desktop/pull/120