### PR TITLE
Fix up the configure check for dbus directories.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,15 +136,22 @@ dnl - Are we specifying a different dbus root ?
 AC_ARG_WITH(dbus-sys,
         [AC_HELP_STRING([--with-dbus-sys=<dir>],
         [where D-BUS system.d directory is])])
-AC_ARG_WITH(dbus-services,
-        [AC_HELP_STRING([--with-dbus-services=<dir>],
-        [where D-BUS services directory is])])
 if ! test -z "$with_dbus_sys" ; then
         DBUS_SYS_DIR="$with_dbus_sys"
 else
-        DBUS_SYS_DIR='${sysconfdir}/dbus-1/system.d'
+        DBUS_SYS_DIR='${datadir}/dbus-1/system.d'
 fi
 AC_SUBST(DBUS_SYS_DIR)
+
+AC_ARG_WITH(dbus-services,
+        [AC_HELP_STRING([--with-dbus-services=<dir>],
+        [where D-BUS services directory is])])
+if ! test -z "$with_dbus_services" ; then
+        DBUS_SERVICES_DIR="$with_dbus_services"
+else
+        DBUS_SERVICES_DIR='${datadir}/dbus-1/system-services'
+fi
+AC_SUBST(DBUS_SERVICES_DIR)
 
 dnl ---------------------------------------------------------------------------
 dnl - GUdev integration (default enabled)
@@ -310,24 +317,6 @@ else
 fi
 
 AC_SUBST(NSS_DATABASE)
-
-dnl ---------------------------------------------------------------------------
-dnl - Check for D-Bus
-dnl ---------------------------------------------------------------------------
-
-dnl - Are we specifying a different dbus root ?
-AC_ARG_WITH(dbus-sys,
-        [AC_HELP_STRING([--with-dbus-sys=<dir>],
-        [where D-BUS system.d directory is])])
-AC_ARG_WITH(dbus-services,
-        [AC_HELP_STRING([--with-dbus-services=<dir>],
-        [where D-BUS services directory is])])
-if ! test -z "$with_dbus_sys" ; then
-        DBUS_SYS_DIR="$with_dbus_sys"
-else
-        DBUS_SYS_DIR='${sysconfdir}/dbus-1/system.d'
-fi
-AC_SUBST(DBUS_SYS_DIR)
 
 # ---------------------------------------------------------------------------
 # PolicyKit for the date & time mechanism

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -26,8 +26,6 @@ pkgconfig_DATA = cinnamon-settings-daemon.pc
 
 @INTLTOOL_XML_NOMERGE_RULE@
 
-dbusservice_in_files = org.freedesktop.IBus.service.in
-
 EXTRA_DIST = 					\
 	$(man_MANS)				\
 	$(convert_DATA)				\

--- a/data/org.freedesktop.IBus.service.in
+++ b/data/org.freedesktop.IBus.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.freedesktop.IBus
-Exec=@bindir@/ibus-daemon --replace --xim --panel disable

--- a/debian/cinnamon-settings-daemon.install
+++ b/debian/cinnamon-settings-daemon.install
@@ -1,5 +1,4 @@
 debian/source_cinnamon-settings-daemon.py /usr/share/apport/package-hooks
-etc/dbus-1/system.d/org.cinnamon.SettingsDaemon.DateTimeMechanism.conf
 etc/xdg/autostart/*
 usr/lib/*/cinnamon-settings-daemon*/*.so
 usr/lib/*/cinnamon-settings-daemon/

--- a/debian/cinnamon-settings-daemon.maintscript
+++ b/debian/cinnamon-settings-daemon.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/dbus-1/system.d/org.cinnamon.SettingsDaemon.DateTimeMechanism.conf

--- a/plugins/datetime/Makefile.am
+++ b/plugins/datetime/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = datetime
 
-dbus_servicesdir = $(datadir)/dbus-1/system-services
-dbus_confdir = $(sysconfdir)/dbus-1/system.d
+dbus_servicesdir = @DBUS_SERVICES_DIR@
+dbus_confdir = @DBUS_SYS_DIR@
 polkitdir = $(datadir)/polkit-1/actions
 
 dbus_services_in_files = org.cinnamon.SettingsDaemon.DateTimeMechanism.service.in


### PR DESCRIPTION
In commit 139c7137525ab29ddfc4a6abfd6287cd3f626c22 the datetime plugin was (re)added to the tree, but the checks designed to control where the dbus files were placed, never did anything.

Make this work, and also change the default location of system.d to be more consistent with the services directory, i.e. in the datadir which is typically reserved for packaged software.