### PR TITLE
Fix Shutdown immediately not working

### DIFF
--- a/plugins/media-keys/csd-media-keys-manager.c
+++ b/plugins/media-keys/csd-media-keys-manager.c
@@ -1483,8 +1483,7 @@ do_config_power_action (CsdMediaKeysManager *manager,
                 cinnamon_session_shutdown (manager);
                 break;
         case CSD_POWER_ACTION_SHUTDOWN:
-                //FIXME: A wee bit cheating here...
-                execute (manager, "dbus-send --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.RequestShutdown", FALSE);
+                csd_power_poweroff (manager->priv->use_logind);
                 break;
         case CSD_POWER_ACTION_HIBERNATE:
                 csd_power_hibernate (manager->priv->use_logind);


### PR DESCRIPTION
New command to power off thanks to systemd that actually works. Not sure when that old command stopped working.
Only issue with this is it may not be distro agnostic
Fixes https://github.com/linuxmint/mint19.2-beta/issues/26