### PR TITLE
Move D-Bus conf file to $(datadir)/dbus-1/system.d

### DIFF
--- a/plugins/datetime/Makefile.am
+++ b/plugins/datetime/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = datetime
 
 dbus_servicesdir = $(datadir)/dbus-1/system-services
-dbus_confdir = $(sysconfdir)/dbus-1/system.d
+dbus_confdir = $(datadir)/dbus-1/system.d
 polkitdir = $(datadir)/polkit-1/actions
 
 dbus_services_in_files = org.cinnamon.SettingsDaemon.DateTimeMechanism.service.in


### PR DESCRIPTION
Since D-Bus 1.9.18 configuration files installed by third-party
software should go in $(datadir)/dbus-1/system.d.  The old location
is for sysadmin overrides.

https://lists.freedesktop.org/archives/dbus/2015-July/016746.html