### PR TITLE
Restore old check for logind

### DIFF
--- a/cinnamon-settings-daemon/cinnamon-settings-session.c
+++ b/cinnamon-settings-daemon/cinnamon-settings-session.c
@@ -378,7 +378,7 @@ cinnamon_settings_session_init (CinnamonSettingsSession *session)
 	session->priv = CINNAMON_SETTINGS_SESSION_GET_PRIVATE (session);
 
 #ifdef HAVE_LOGIND
-    if (access("/run/systemd/system/", F_OK) == 0) {    // sd_booted ()
+    if (access("/run/systemd/seats/", F_OK) == 0) {    // sd_booted ()
         sd_pid_get_session (getpid(), &session->priv->session_id);
         session->priv->sd_source = sd_source_new ();
         g_source_set_callback (session->priv->sd_source, sessions_changed, session, NULL);

--- a/plugins/common/csd-power-helper.c
+++ b/plugins/common/csd-power-helper.c
@@ -41,7 +41,7 @@ use_logind (void)
     static gsize once_init_value = 0;
 
     if (g_once_init_enter (&once_init_value)) {
-        should_use_logind = access("/run/systemd/system/", F_OK) == 0; // sd_booted ()
+        should_use_logind = access("/run/systemd/seats/", F_OK) == 0; // sd_booted ()
 
         g_once_init_leave (&once_init_value, 1);
     }


### PR DESCRIPTION
ls /run/systemd/system/ returns nothing here

ls /run/systemd/seats
seat0

Based on https://github.com/linuxmint/cinnamon-session/commit/82b0cd50a046e6fa266ba93e549b66787f899c75
