### PR TITLE
Fix the build in highly-concurrent scenarios

### DIFF
--- a/plugins/power/Makefile.am
+++ b/plugins/power/Makefile.am
@@ -41,6 +41,8 @@ csd-power-keyboard-proxy.h : Makefile.am org.cinnamon.SettingsDaemon.Power.Keybo
 		$(NULL)
 csd-power-keyboard-proxy.c : csd-power-keyboard-proxy.h
 
+csd-power-manager.c : csd-power-proxy.h csd-power-screen-proxy.h csd-power-keyboard-proxy.h
+
 libexec_PROGRAMS = csd-power
 csd_power_SOURCES =				\
 	gpm-common.c					\


### PR DESCRIPTION
Some of the header files are generated using the `gdbus-codegen` tool, namely `csd-power-proxy.h`, `csd-power-screen-proxy.h` and `csd-power-keyboard-proxy.h`. There are rules to specify source files that depend on these headers, however `csd-power-manager.c` depends on all three of them and is not specified as a dependent source file. This leads to race condition on highly parallelized builds, where the source file compilation would be attempted before the headers are generated, leading to errors like:

```
csd-power-manager.c:50:10: fatal error: csd-power-proxy.h: No such file or directory
 #include "csd-power-proxy.h"
          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
```

fixes #248 