### PR TITLE
do not delete programs and replace them with broken symlinks to themselves

### DIFF
--- a/plugins/a11y-keyboard/meson.build
+++ b/plugins/a11y-keyboard/meson.build
@@ -25,7 +25,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-a11y-keyboard')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-a11y-keyboard')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-a11y-keyboard')
+endif
 
 test_a11y_prefs_dialog_sources = [
     'csd-a11y-preferences-dialog.c',

--- a/plugins/a11y-settings/meson.build
+++ b/plugins/a11y-settings/meson.build
@@ -24,7 +24,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-a11y-settings')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-a11y-settings')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-a11y-settings')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-a11y-settings.desktop.in',

--- a/plugins/automount/meson.build
+++ b/plugins/automount/meson.build
@@ -26,7 +26,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-automount')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-automount')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-automount')
+endif
 
 test_automount_dialog_sources = [
     'test-automount-dialog.c',

--- a/plugins/background/meson.build
+++ b/plugins/background/meson.build
@@ -25,7 +25,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-background')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-background')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-background')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-background.desktop.in',

--- a/plugins/clipboard/meson.build
+++ b/plugins/clipboard/meson.build
@@ -26,7 +26,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-clipboard')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-clipboard')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-clipboard')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-clipboard.desktop.in',

--- a/plugins/color/meson.build
+++ b/plugins/color/meson.build
@@ -34,7 +34,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-color')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-color')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-color')
+endif
 
 test_color_sources = [
     'gcm-dmi.c',

--- a/plugins/common/meson.build
+++ b/plugins/common/meson.build
@@ -40,7 +40,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-input-helper')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-input-helper')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-input-helper')
+endif
 
 install_data(
     'input-device-example.sh',

--- a/plugins/cursor/meson.build
+++ b/plugins/cursor/meson.build
@@ -25,7 +25,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-cursor')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-cursor')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-cursor')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-cursor.desktop.in',

--- a/plugins/datetime/meson.build
+++ b/plugins/datetime/meson.build
@@ -61,7 +61,9 @@ if polkit.found()
     )
 
     meson.add_install_script(ln_script, libexecdir, bindir, 'csd-datetime-mechanism')
-    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-datetime-mechanism')
+    if libexecdir != pkglibdir
+        meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-datetime-mechanism')
+    endif
 
     executable(
         'test-datetime',

--- a/plugins/housekeeping/meson.build
+++ b/plugins/housekeeping/meson.build
@@ -31,7 +31,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-housekeeping')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-housekeeping')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-housekeeping')
+endif
 
 test_disk_space_sources = [
     'csd-disk-space-test.c',

--- a/plugins/keyboard/meson.build
+++ b/plugins/keyboard/meson.build
@@ -31,7 +31,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-keyboard')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-keyboard')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-keyboard')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-keyboard.desktop.in',

--- a/plugins/media-keys/meson.build
+++ b/plugins/media-keys/meson.build
@@ -31,7 +31,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-media-keys')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-media-keys')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-media-keys')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-media-keys.desktop.in',

--- a/plugins/mouse/meson.build
+++ b/plugins/mouse/meson.build
@@ -30,7 +30,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-mouse')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-mouse')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-mouse')
+endif
 
 executable(
     'csd-locate-pointer',
@@ -42,7 +44,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-locate-pointer')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-locate-pointer')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-locate-pointer')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-mouse.desktop.in',

--- a/plugins/orientation/meson.build
+++ b/plugins/orientation/meson.build
@@ -25,7 +25,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-orientation')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-orientation')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-orientation')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-orientation.desktop.in',

--- a/plugins/power/meson.build
+++ b/plugins/power/meson.build
@@ -67,7 +67,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-power')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-power')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-power')
+endif
 
 if gudev.found()
     executable(
@@ -83,7 +85,9 @@ if gudev.found()
     )
 
     meson.add_install_script(ln_script, libexecdir, bindir, 'csd-backlight-helper')
-    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-backlight-helper')
+    if libexecdir != pkglibdir
+        meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-backlight-helper')
+    endif
 endif
 
 configure_file(

--- a/plugins/print-notifications/meson.build
+++ b/plugins/print-notifications/meson.build
@@ -30,7 +30,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-print-notifications')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-print-notifications')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-print-notifications')
+endif
 
 executable(
     'csd-printer',
@@ -42,7 +44,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-printer')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-printer')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-printer')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-print-notifications.desktop.in',

--- a/plugins/screensaver-proxy/meson.build
+++ b/plugins/screensaver-proxy/meson.build
@@ -24,7 +24,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-screensaver-proxy')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-screensaver-proxy')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-screensaver-proxy')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-screensaver-proxy.desktop.in',

--- a/plugins/smartcard/meson.build
+++ b/plugins/smartcard/meson.build
@@ -26,7 +26,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-smartcard')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-smartcard')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-smartcard')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-smartcard.desktop.in',

--- a/plugins/sound/meson.build
+++ b/plugins/sound/meson.build
@@ -28,7 +28,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-sound')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-sound')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-sound')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-sound.desktop.in',

--- a/plugins/wacom/meson.build
+++ b/plugins/wacom/meson.build
@@ -62,7 +62,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-wacom')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-wacom')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-wacom')
+endif
 
 if gudev.found()
     executable(
@@ -75,7 +77,9 @@ if gudev.found()
     )
 
     meson.add_install_script(ln_script, libexecdir, bindir, 'csd-wacom-led-helper')
-    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-wacom-led-helper')
+    if libexecdir != pkglibdir
+        meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-wacom-led-helper')
+    endif
 endif
 
 executable(
@@ -88,7 +92,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-list-wacom')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-list-wacom')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-list-wacom')
+endif
 
 executable(
     'csd-wacom-osd',
@@ -100,7 +106,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-wacom-osd')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-wacom-osd')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-wacom-osd')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-wacom.desktop.in',

--- a/plugins/xrandr/meson.build
+++ b/plugins/xrandr/meson.build
@@ -27,7 +27,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-xrandr')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-xrandr')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-xrandr')
+endif
 
 configure_file(
     input: 'cinnamon-settings-daemon-xrandr.desktop.in',

--- a/plugins/xsettings/meson.build
+++ b/plugins/xsettings/meson.build
@@ -40,7 +40,9 @@ executable(
 )
 
 meson.add_install_script(ln_script, libexecdir, bindir, 'csd-xsettings')
-meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-xsettings')
+if libexecdir != pkglibdir
+    meson.add_install_script(ln_script, libexecdir, pkglibdir, 'csd-xsettings')
+endif
 
 executable(
     'test-gtk-modules',


### PR DESCRIPTION
commit 67d8cc67f666b726c2d76b6c1c6eb1dcc4cc53cc tries to ensure the programs are available from multiple locations, because users might have custom desktop files with broken paths. Unfortunately it does so by unconditionally deleting one of those locations!

This is exceedingly problematic on distros that do not use the lib vs. libexec split, because libexecdir == pkglibdir, hence the install script first deletes the program itself, then creates a symlink pointing to itself.

```
$ tree pkg/usr/lib/cinnamon-settings-daemon
pkg/usr/lib/cinnamon-settings-daemon
├── csd-a11y-keyboard -> csd-a11y-keyboard
├── csd-a11y-settings -> csd-a11y-settings
├── csd-automount -> csd-automount
├── csd-background -> csd-background
├── csd-backlight-helper -> csd-backlight-helper
├── csd-clipboard -> csd-clipboard
├── csd-color -> csd-color
├── csd-cursor -> csd-cursor
├── csd-datetime-mechanism -> csd-datetime-mechanism
├── csd-housekeeping -> csd-housekeeping
├── csd-input-helper -> csd-input-helper
├── csd-keyboard -> csd-keyboard
├── csd-list-wacom -> csd-list-wacom
├── csd-locate-pointer -> csd-locate-pointer
├── csd-media-keys -> csd-media-keys
├── csd-mouse -> csd-mouse
├── csd-orientation -> csd-orientation
├── csd-power -> csd-power
├── csd-printer -> csd-printer
├── csd-print-notifications -> csd-print-notifications
├── csd-screensaver-proxy -> csd-screensaver-proxy
├── csd-smartcard -> csd-smartcard
├── csd-sound -> csd-sound
├── csd-wacom -> csd-wacom
├── csd-wacom-led-helper -> csd-wacom-led-helper
├── csd-wacom-osd -> csd-wacom-osd
├── csd-xrandr -> csd-xrandr
└── csd-xsettings -> csd-xsettings
```

Fixes https://bugs.archlinux.org/task/69309
Fixes regression in #320