### PR TITLE
[Needs Testing] wacom: Fix a crashes from assertion failures (re-pr)

### DIFF
--- a/plugins/wacom/csd-wacom-device.c
+++ b/plugins/wacom/csd-wacom-device.c
@@ -1854,7 +1854,7 @@ csd_wacom_device_set_current_stylus (CsdWacomDevice *device,
 		   stylus_id, device->priv->name);
 
 	/* Setting the default stylus to be the first one */
-	g_assert (device->priv->styli);
+	g_return_if_fail (device->priv->styli != NULL);
 
 	stylus = device->priv->styli->data;
 	g_object_set (device, "last-stylus", stylus, NULL);


### PR DESCRIPTION
If the device stylus isn't recognized from the wacom kernel module it 
will just crash the module.

The real fix is to update the kernel and (maybe) prevent it from 
crashing wacom. This would leave the tablet in an undefined state.

Closes:
https://github.com/linuxmint/cinnamon-settings-daemon/issues/332


-------------------------------------------------------
what the heck happened in #334, i just force-pushed and it closed