### PR TITLE
EDID strings can be up to 13 bytes

### DIFF
--- a/plugins/color/gcm-edid.c
+++ b/plugins/color/gcm-edid.c
@@ -341,7 +341,7 @@ gcm_edid_parse (GcmEdid *edid, const guint8 *data, gsize length, GError **error)
 
         /* get color red */
         priv->red->x = gcm_edid_decode_fraction (data[0x1b], gcm_edid_get_bits (data[0x19], 6, 7));
-        priv->red->y = gcm_edid_decode_fraction (data[0x1c], gcm_edid_get_bits (data[0x19], 5, 4));
+        priv->red->y = gcm_edid_decode_fraction (data[0x1c], gcm_edid_get_bits (data[0x19], 4, 5));
 
         /* get color green */
         priv->green->x = gcm_edid_decode_fraction (data[0x1d], gcm_edid_get_bits (data[0x19], 2, 3));

--- a/plugins/color/gcm-edid.c
+++ b/plugins/color/gcm-edid.c
@@ -240,9 +240,9 @@ gcm_edid_parse_string (const guint8 *data)
         guint i;
         guint replaced = 0;
 
-        /* this is always 12 bytes, but we can't guarantee it's null
+        /* this is always 13 bytes, but we can't guarantee it's null
          * terminated or not junk. */
-        text = g_strndup ((const gchar *) data, 12);
+        text = g_strndup ((const gchar *) data, 13);
 
         /* remove insane newline chars */
         g_strdelimit (text, "\n\r", '\0');


### PR DESCRIPTION
Based on https://github.com/GNOME/gnome-settings-daemon/commit/7935a97354a950077d95655453b604669155c457
and https://github.com/GNOME/gnome-settings-daemon/commit/d948c8caf3dee1652e8ed05016a1b306dfa0fdf7