### PR TITLE
Fixes #359: Do only rotate if tablet mode is active

### DIFF
--- a/data/org.cinnamon.settings-daemon.peripherals.gschema.xml.in.in
+++ b/data/org.cinnamon.settings-daemon.peripherals.gschema.xml.in.in
@@ -188,6 +188,10 @@
       <default>true</default>
       <summary>Whether the tablet's orientation is locked, or rotated automatically.</summary>
     </key>
+    <key name="tabletmode-lock" type="b">
+      <default>true</default>
+      <summary>Whether the tablet's orientation is locked if it is not in tablet mode.</summary>
+    </key>
   </schema>
   <schema gettext-domain="@GETTEXT_PACKAGE@" id="org.cinnamon.settings-daemon.peripherals.trackball" path="/org/cinnamon/settings-daemon/peripherals/trackball/">
     <key name="scroll-wheel-emulation-button" type="i">

--- a/plugins/orientation/meson.build
+++ b/plugins/orientation/meson.build
@@ -10,6 +10,7 @@ orientation_deps = [
     common_dep,
     csd_dep,
     libnotify,
+    dependency('threads'),
 ]
 
 executable(


### PR DESCRIPTION
Implemented Feature described in https://github.com/linuxmint/cinnamon-settings-daemon/issues/359. A switch in the settings GUI is not covered as this task belongs to another repository (see also https://github.com/linuxmint/cinnamon/issues/10697).