### PR TITLE
csd-media-keys-manager.c: Fix volume level 5% snap

### DIFF
--- a/plugins/media-keys/csd-media-keys-manager.c
+++ b/plugins/media-keys/csd-media-keys-manager.c
@@ -1038,7 +1038,7 @@ do_sound_action (CsdMediaKeysManager *manager,
                 /* When coming out of mute only increase the volume if it was 0 */
                 if (!old_muted || old_vol_pa == 0) {
                         if (old_vol_pa % vol_step_pa > 0 && !CROSSING_PA_NORM (old_vol_pa, vol_step_pa)) {
-                                new_vol_pa = MIN (old_vol_pa / vol_step_pa * vol_step_pa, max_vol_pa);
+                                new_vol_pa = MIN (old_vol_pa / vol_step_pa * vol_step_pa + vol_step_pa, max_vol_pa);
                         } else {
                                 new_vol_pa = MIN (old_vol_pa / vol_step_pa * vol_step_pa + vol_step_pa, max_vol_pa);
                         }


### PR DESCRIPTION
On VOLUME_UP key press, we want to snap volume up to the nearest 5% step. Currently, volume snaps to the lower 5% step by integer division. Compare with VOLUME_DOWN code

Reports describing the bug:
https://github.com/linuxmint/cinnamon/issues/10048
https://github.com/linuxmint/cinnamon/issues/10269