### PR TITLE
csd-power-manager.c: Ensure that dbus message "g-properties-changed" is emitted in all relevant places

### DIFF
--- a/plugins/power/csd-power-manager.c
+++ b/plugins/power/csd-power-manager.c
@@ -914,10 +914,10 @@ engine_update_composite_device (CsdPowerManager *manager,
                       "state", state,
                       NULL);
 
-        /* force update of icon */
-        if (engine_recalculate_state_icon (manager))
-                engine_emit_changed (manager, TRUE, FALSE);
 out:
+        /* force update of icon */
+	engine_recalculate_state (manager);
+	
         /* return composite device or original device */
         return device;
 }
@@ -2440,6 +2440,8 @@ up_client_changed_cb (UpClient *client, CsdPowerManager *manager)
                 do_lid_closed_action (manager);
         else
                 do_lid_open_action (manager);
+	
+	engine_recalculate_state (manager);
 }
 
 typedef enum {


### PR DESCRIPTION
I wanted to dig into issues with power applet when it's not updating state of batteries and found out that "g-properties-changed" is not always appearing on dbus when connecting/disconnecting AC or opening lid. There are two suspicious places where i think `engine_emit_changed` (in the body of `engine_recalculate_state`) should be called so added it.