### PR TITLE
build: add missing gio-unix-2.0 dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,7 @@ cups = dependency('cups', version: '>= 1.4', required: get_option('use_cups'))
 cvc = dependency('cvc', version: cinnamon_desktop_required)
 fontconfig = dependency('fontconfig')
 gio = dependency('gio-2.0', version: '>= 2.40.0')
+gio_unix = dependency('gio-unix-2.0', version: '>= 2.40.0')
 glib = dependency('glib-2.0', version: '>= 2.40.0')
 gnomekbd_required = '>= 3.6.0'
 gnomekbd = dependency('libgnomekbd', version: gnomekbd_required)

--- a/plugins/datetime/meson.build
+++ b/plugins/datetime/meson.build
@@ -37,7 +37,8 @@ datetime_deps = [
     libnotify,
     polkit,
     xfixes,
-    gio
+    gio,
+    gio_unix
 ]
 
 if polkit.found()

--- a/plugins/housekeeping/meson.build
+++ b/plugins/housekeeping/meson.build
@@ -15,6 +15,7 @@ housekeeping_sources = [
 housekeeping_deps = [
     common_dep,
     csd_dep,
+    gio_unix,
     libnotify,
 ]
 

--- a/plugins/media-keys/meson.build
+++ b/plugins/media-keys/meson.build
@@ -13,6 +13,7 @@ media_keys_deps = [
     common_dep,
     csd_dep,
     cvc,
+    gio_unix,
     gudev,
     libnotify,
     math,

--- a/plugins/power/meson.build
+++ b/plugins/power/meson.build
@@ -47,6 +47,7 @@ power_deps = [
     cinnamon_desktop,
     common_dep,
     csd_dep,
+    gio_unix,
     libnotify,
     math,
     upower_glib,


### PR DESCRIPTION
The Nix package manager used by NixOS (and available on all unix systems), uses a sandboxed environment where it is not possible to have global building dependencies. Without this change the build with fails with:

```
[38/139] Compiling C object plugins/datetime/csd-datetime-mechanism.p/meson-generated_.._csd-exported-datetime.c.o
FAILED: plugins/datetime/csd-datetime-mechanism.p/meson-generated_.._csd-exported-datetime.c.o 
gcc -Iplugins/datetime/csd-datetime-mechanism.p -Iplugins/datetime -I../plugins/datetime -I. -I.. -Icinnamon-settings-daemon -I../cinnamon-settings-daemon -Iplugins/common -I../plugins/common -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/i4k2ahrb0rzr7f2ni02nljcffawvpqpg-glib-2.72.3/lib/glib-2.0/include -I/nix/store/qbvaw0nl5rvmwm6ljsmvq7ciazqvcd2j-gtk+3-3.24.34-dev/include/gtk-3.0 -I/nix/store/mkn4f22mpfk654j46r5644fvg73cxz82-atk-2.38.0-dev/include/atk-1.0 -I/nix/store/vxkj5z9f1fb1vpygxxxpncy9x1aay4k7-cairo-1.16.0-dev/include/cairo -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include/freetype2 -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include -I/nix/store/v99pf1pni85bxccfn1yhy4fanq4idagw-gdk-pixbuf-2.42.8-dev/include/gdk-pixbuf-2.0 -I/nix/store/x61p9rbkrh362sl3xxzhw1qvnlklylam-pango-1.50.7-dev/include/pango-1.0 -I/nix/store/qpglawyvc4ybhqkkz368zlpq1gw00h44-harfbuzz-3.3.2-dev/include/harfbuzz -I/nix/store/9wcm2vn1kdg725cximpvzaalx89bzgmf-xorgproto-2021.5/include -I/nix/store/xqahkgsh844in1clizx358d6iim0kp32-libX11-1.7.2-dev/include -I/nix/store/21hzv9lvh9cz3pp3j53wdqwh96gvbizh-libXi-1.8-dev/include -I/nix/store/v3azkd8y9vhhkvia3a7mxgcdsql0vici-systemd-250.4-dev/include -I/nix/store/xnsdrm1rdj6ph4dyhyxx433bcm4bc6hv-libnotify-0.7.12-dev/include -I/nix/store/y7cz77rq19n0wlqszfhqkdzv4jvksk7d-polkit-0.120-dev/include/polkit-1 -I/nix/store/zzh7fpzaxvdpx998l1q0ajzszg87sqyj-libXfixes-6.0.0-dev/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -DHAVE_NEW_LCMS -DHAVE_LOGIND -DHAVE_GUDEV -DHAVE_WACOM -Wno-deprecated-declarations -Wno-deprecated -Wno-declaration-after-statement -DGLIB_DISABLE_DEPRECATION_WARNINGS '-DPLUGIN_NAME="clipboard"' -MD -MQ plugins/datetime/csd-datetime-mechanism.p/meson-generated_.._csd-exported-datetime.c.o -MF plugins/datetime/csd-datetime-mechanism.p/meson-generated_.._csd-exported-datetime.c.o.d -o plugins/datetime/csd-datetime-mechanism.p/meson-generated_.._csd-exported-datetime.c.o -c plugins/datetime/csd-exported-datetime.c
plugins/datetime/csd-exported-datetime.c:17:12: fatal error: gio/gunixfdlist.h: No such file or directory
   17 | #  include <gio/gunixfdlist.h>
      |            ^~~~~~~~~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.
```

```
[49/139] Compiling C object plugins/housekeeping/csd-housekeeping.p/csd-disk-space.c.o
FAILED: plugins/housekeeping/csd-housekeeping.p/csd-disk-space.c.o 
gcc -Iplugins/housekeeping/csd-housekeeping.p -Iplugins/housekeeping -I../plugins/housekeeping -I. -I.. -Icinnamon-settings-daemon -I../cinnamon-settings-daemon -Iplugins/common -I../plugins/common -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/i4k2ahrb0rzr7f2ni02nljcffawvpqpg-glib-2.72.3/lib/glib-2.0/include -I/nix/store/qbvaw0nl5rvmwm6ljsmvq7ciazqvcd2j-gtk+3-3.24.34-dev/include/gtk-3.0 -I/nix/store/mkn4f22mpfk654j46r5644fvg73cxz82-atk-2.38.0-dev/include/atk-1.0 -I/nix/store/vxkj5z9f1fb1vpygxxxpncy9x1aay4k7-cairo-1.16.0-dev/include/cairo -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include/freetype2 -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include -I/nix/store/v99pf1pni85bxccfn1yhy4fanq4idagw-gdk-pixbuf-2.42.8-dev/include/gdk-pixbuf-2.0 -I/nix/store/x61p9rbkrh362sl3xxzhw1qvnlklylam-pango-1.50.7-dev/include/pango-1.0 -I/nix/store/qpglawyvc4ybhqkkz368zlpq1gw00h44-harfbuzz-3.3.2-dev/include/harfbuzz -I/nix/store/9wcm2vn1kdg725cximpvzaalx89bzgmf-xorgproto-2021.5/include -I/nix/store/xqahkgsh844in1clizx358d6iim0kp32-libX11-1.7.2-dev/include -I/nix/store/21hzv9lvh9cz3pp3j53wdqwh96gvbizh-libXi-1.8-dev/include -I/nix/store/v3azkd8y9vhhkvia3a7mxgcdsql0vici-systemd-250.4-dev/include -I/nix/store/xnsdrm1rdj6ph4dyhyxx433bcm4bc6hv-libnotify-0.7.12-dev/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -DHAVE_NEW_LCMS -DHAVE_LOGIND -DHAVE_GUDEV -DHAVE_WACOM -Wno-deprecated-declarations -Wno-deprecated -Wno-declaration-after-statement -DGLIB_DISABLE_DEPRECATION_WARNINGS '-DPLUGIN_NAME="housekeeping"' -MD -MQ plugins/housekeeping/csd-housekeeping.p/csd-disk-space.c.o -MF plugins/housekeeping/csd-housekeeping.p/csd-disk-space.c.o.d -o plugins/housekeeping/csd-housekeeping.p/csd-disk-space.c.o -c ../plugins/housekeeping/csd-disk-space.c
../plugins/housekeeping/csd-disk-space.c:33:10: fatal error: gio/gunixmounts.h: No such file or directory
   33 | #include <gio/gunixmounts.h>
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.
```

```
[69/139] Compiling C object plugins/media-keys/csd-media-keys.p/csd-media-keys-manager.c.o
FAILED: plugins/media-keys/csd-media-keys.p/csd-media-keys-manager.c.o 
gcc -Iplugins/media-keys/csd-media-keys.p -Iplugins/media-keys -I../plugins/media-keys -I. -I.. -Icinnamon-settings-daemon -I../cinnamon-settings-daemon -Iplugins/common -I../plugins/common -Idata -I../data -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/i4k2ahrb0rzr7f2ni02nljcffawvpqpg-glib-2.72.3/lib/glib-2.0/include -I/nix/store/qbvaw0nl5rvmwm6ljsmvq7ciazqvcd2j-gtk+3-3.24.34-dev/include/gtk-3.0 -I/nix/store/mkn4f22mpfk654j46r5644fvg73cxz82-atk-2.38.0-dev/include/atk-1.0 -I/nix/store/vxkj5z9f1fb1vpygxxxpncy9x1aay4k7-cairo-1.16.0-dev/include/cairo -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include/freetype2 -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include -I/nix/store/v99pf1pni85bxccfn1yhy4fanq4idagw-gdk-pixbuf-2.42.8-dev/include/gdk-pixbuf-2.0 -I/nix/store/x61p9rbkrh362sl3xxzhw1qvnlklylam-pango-1.50.7-dev/include/pango-1.0 -I/nix/store/qpglawyvc4ybhqkkz368zlpq1gw00h44-harfbuzz-3.3.2-dev/include/harfbuzz -I/nix/store/7gszq789hr66kcz2p2h3i0y255bhsfma-libcanberra-0.30/include -I/nix/store/fv80fbb38zy7p2x1xbhsmqakfiyjqkjh-cinnamon-desktop-5.4.1-dev/include/cinnamon-desktop -I/nix/store/9wcm2vn1kdg725cximpvzaalx89bzgmf-xorgproto-2021.5/include -I/nix/store/xqahkgsh844in1clizx358d6iim0kp32-libX11-1.7.2-dev/include -I/nix/store/21hzv9lvh9cz3pp3j53wdqwh96gvbizh-libXi-1.8-dev/include -I/nix/store/v3azkd8y9vhhkvia3a7mxgcdsql0vici-systemd-250.4-dev/include -I/nix/store/fv80fbb38zy7p2x1xbhsmqakfiyjqkjh-cinnamon-desktop-5.4.1-dev/include/cinnamon-desktop/libcvc -I/nix/store/p6i9r76i4y7j784gva5xvhshvflvrid3-pulseaudio-15.0-dev/include -I/nix/store/ir19m4irmngx195s8yw21yk344y4g513-libgudev-237-dev/include/gudev-1.0 -I/nix/store/xnsdrm1rdj6ph4dyhyxx433bcm4bc6hv-libnotify-0.7.12-dev/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -DHAVE_NEW_LCMS -DHAVE_LOGIND -DHAVE_GUDEV -DHAVE_WACOM -Wno-deprecated-declarations -Wno-deprecated -Wno-declaration-after-statement -DGLIB_DISABLE_DEPRECATION_WARNINGS -D_REENTRANT '-DPLUGIN_NAME="media-keys"' -MD -MQ plugins/media-keys/csd-media-keys.p/csd-media-keys-manager.c.o -MF plugins/media-keys/csd-media-keys.p/csd-media-keys-manager.c.o.d -o plugins/media-keys/csd-media-keys.p/csd-media-keys-manager.c.o -c ../plugins/media-keys/csd-media-keys-manager.c
../plugins/media-keys/csd-media-keys-manager.c:41:10: fatal error: gio/gdesktopappinfo.h: No such file or directory
   41 | #include <gio/gdesktopappinfo.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.
```

```
[82/139] Compiling C object plugins/power/csd-power.p/meson-generated_.._csd-power-proxy.c.o
FAILED: plugins/power/csd-power.p/meson-generated_.._csd-power-proxy.c.o 
gcc -Iplugins/power/csd-power.p -Iplugins/power -I../plugins/power -I. -I.. -Icinnamon-settings-daemon -I../cinnamon-settings-daemon -Iplugins/common -I../plugins/common -Idata -I../data -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/i4k2ahrb0rzr7f2ni02nljcffawvpqpg-glib-2.72.3/lib/glib-2.0/include -I/nix/store/qbvaw0nl5rvmwm6ljsmvq7ciazqvcd2j-gtk+3-3.24.34-dev/include/gtk-3.0 -I/nix/store/mkn4f22mpfk654j46r5644fvg73cxz82-atk-2.38.0-dev/include/atk-1.0 -I/nix/store/vxkj5z9f1fb1vpygxxxpncy9x1aay4k7-cairo-1.16.0-dev/include/cairo -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include/freetype2 -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include -I/nix/store/v99pf1pni85bxccfn1yhy4fanq4idagw-gdk-pixbuf-2.42.8-dev/include/gdk-pixbuf-2.0 -I/nix/store/x61p9rbkrh362sl3xxzhw1qvnlklylam-pango-1.50.7-dev/include/pango-1.0 -I/nix/store/qpglawyvc4ybhqkkz368zlpq1gw00h44-harfbuzz-3.3.2-dev/include/harfbuzz -I/nix/store/7gszq789hr66kcz2p2h3i0y255bhsfma-libcanberra-0.30/include -I/nix/store/fv80fbb38zy7p2x1xbhsmqakfiyjqkjh-cinnamon-desktop-5.4.1-dev/include/cinnamon-desktop -I/nix/store/9wcm2vn1kdg725cximpvzaalx89bzgmf-xorgproto-2021.5/include -I/nix/store/xqahkgsh844in1clizx358d6iim0kp32-libX11-1.7.2-dev/include -I/nix/store/21hzv9lvh9cz3pp3j53wdqwh96gvbizh-libXi-1.8-dev/include -I/nix/store/v3azkd8y9vhhkvia3a7mxgcdsql0vici-systemd-250.4-dev/include -I/nix/store/xnsdrm1rdj6ph4dyhyxx433bcm4bc6hv-libnotify-0.7.12-dev/include -I/nix/store/i4sx4xv0pabvimczms6446albigb4nqp-upower-0.99.19-dev/include/libupower-glib -I/nix/store/kl9n24h72y78sr8d8k54p88gyz1xz9vs-libXext-1.3.4-dev/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -DHAVE_NEW_LCMS -DHAVE_LOGIND -DHAVE_GUDEV -DHAVE_WACOM -Wno-deprecated-declarations -Wno-deprecated -Wno-declaration-after-statement -DGLIB_DISABLE_DEPRECATION_WARNINGS -D_REENTRANT '-DPLUGIN_NAME="power"' -MD -MQ plugins/power/csd-power.p/meson-generated_.._csd-power-proxy.c.o -MF plugins/power/csd-power.p/meson-generated_.._csd-power-proxy.c.o.d -o plugins/power/csd-power.p/meson-generated_.._csd-power-proxy.c.o -c plugins/power/csd-power-proxy.c
plugins/power/csd-power-proxy.c:17:12: fatal error: gio/gunixfdlist.h: No such file or directory
   17 | #  include <gio/gunixfdlist.h>
      |            ^~~~~~~~~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.
```

See also 

- https://github.com/NixOS/nixpkgs/issues/36468

Thanks for reviewing this :-)