### PR TITLE
Fix broken rpath

### DIFF
--- a/plugins/wacom/meson.build
+++ b/plugins/wacom/meson.build
@@ -27,7 +27,7 @@ executable(
   dependencies: deps,
   c_args: cflags,
   install: true,
-  install_rpath: pkglibdir,
+  install_rpath: join_paths(prefix, apilibdir),
   install_dir: libexecdir
 )
 
@@ -53,7 +53,7 @@ foreach program: programs
     include_directories: include_dirs,
     dependencies: led_deps,
     install: true,
-    install_rpath: pkglibdir,
+    install_rpath: join_paths(prefix, apilibdir),
     install_dir: libexecdir
   )
  endforeach


### PR DESCRIPTION
 The wacom uses the wrong rpath.

chrpath -l  csd-wacom*
csd-wacom: RUNPATH=lib/x86_64-linux-gnu/cinnamon-settings-daemon
csd-wacom-led-helper: RUNPATH=lib/x86_64-linux-gnu/cinnamon-settings-daemon
csd-wacom-oled-helper: RUNPATH=lib/x86_64-linux-gnu/cinnamon-settings-daemon

It should use  RUNPATH=/usr/lib/x86_64-linux-gnu/cinnamon-settings-daemon-3.0