### PR TITLE
build: don't hardcode files install dir as /

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -148,8 +148,8 @@ subdir('cinnamon-settings-daemon')
 subdir('plugins')
 
 install_subdir(
-    'files',
-    install_dir: '/',
+    'files/usr',
+    install_dir: prefix,
     strip_directory: true,
 )
 


### PR DESCRIPTION
In NixOS packages are installed to their own separate prefix (i.e. `/nix/store/3srl963wzvfm3q3mnbnvrgz34yd93y7q-cinnamon-settings-daemon-5.6.1/share/icons/hicolor` instead of `/usr/share/icons/hicolor`), we don't have permission to write things to `/` in build time (we actually don't have `/usr/share`) :disappointed: 

```
[0/1] Installing files.
Installing subdir /build/source/files to /
Installation failed due to insufficient permissions.
Attempting to use polkit to gain elevated privileges...
pkexec must be setuid root
FAILED: meson-internal__install
/nix/store/754p0izaawcr1v28i0k3xbbj2r3m27n2-meson-0.64.1/bin/meson install --no-rebuild
ninja: build stopped: subcommand failed.
```
https://github.com/NixOS/nixpkgs/blob/4106c75/pkgs/desktops/cinnamon/cinnamon-settings-daemon/use-sane-install-dir.patch

(Yeah we are also carrying the same patch [for cinnamon](https://github.com/NixOS/nixpkgs/blob/4106c75/pkgs/desktops/cinnamon/cinnamon-common/use-sane-install-dir.patch), but it should be fine to upstream the cinnamon-settings-daemon one first since only some icons are included in `files` here and no else paths are hardcoded)