### PR TITLE
power: Add settings to disable low battery warnings for connected devices

### DIFF
--- a/data/org.cinnamon.settings-daemon.plugins.power.gschema.xml.in.in
+++ b/data/org.cinnamon.settings-daemon.plugins.power.gschema.xml.in.in
@@ -155,5 +155,20 @@
       <default>2</default>
       <summary>In percent, minimum allowable brightness adjustment.  This will become 0 percent brightness</summary>
     </key>
+    <key name="power-notifications-for-keyboard" type="b">
+      <default>true</default>
+      <summary>Low battery notifications for wireless keyboard</summary>
+      <description>Whether to show low battery notifications for wireless keyboard devices.</description>
+    </key>
+    <key name="power-notifications-for-mouse" type="b">
+      <default>true</default>
+      <summary>Low battery notifications for wireless mouse</summary>
+      <description>Whether to show low battery notifications for wireless mouse devices.</description>
+    </key>
+    <key name="power-notifications-for-other-devices" type="b">
+      <default>true</default>
+      <summary>Low battery notifications for other connected devices</summary>
+      <description>Whether to show low battery notifications for conected devices other than keyboards and mice.</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
hi,

this is a long requested feature for gnome shell and cinnamon. there are too many posts asking how to disable low battery notifications, and someone even made some scripts that patch and recompile upower for gnome (works for gnome only; cinnamon is too different in this regard).

the problem is that many devices report low battery when they will be able to work fine for a long time, spamming the user with notifications. this happens a lot when users replace alkaline (1.5V nominal) batteries with nickel-based batteries (1.2V nominal). the lower voltage of the rechargeable batteries trigger the warning, but the devices typically work fine with just 1V or less.

this is a quick fix for keyboards and mice, which represent 99+ % of the issue i guess, with a coarse fix for the outliers if any. a different implementation could filter individual devices based on their upower device ID, instead of classes of devices. but i'm not familiar with the dconf system and wouldn't know the best way to implement such "variable schema" on it. (a set of ID strings? who knows.)

something is better than nothing and this implementation is here now, and the problem has been unfixed for ages so i'm obviously pushing to get this in. as i said, this should take care of most users.

the UI will be pushed in a companion PR.

thanks!