### PR TITLE
csd-wacom: remove ifdef code that cannot compile

### DIFF
--- a/plugins/wacom/csd-wacom-manager.c
+++ b/plugins/wacom/csd-wacom-manager.c
@@ -46,10 +46,6 @@
 #include "csd-enums.h"
 #include "cinnamon-settings-profile.h"
 
-#if HAVE_WAYLAND
-#include "cinnamon-settings-bus.h"
-#endif
-
 #include "csd-wacom-manager.h"
 #include "csd-wacom-oled.h"
 #include "migrate-settings.h"
@@ -193,12 +189,7 @@ csd_wacom_manager_class_init (CsdWacomManagerClass *klass)
 static gchar *
 get_device_path (GdkDevice *device)
 {
-#if HAVE_WAYLAND
-        if (gnome_settings_is_wayland ())
-                return g_strdup (gdk_wayland_device_get_node_path (device));
-        else
-#endif
-                return xdevice_get_device_node (gdk_x11_device_get_id (device));
+        return xdevice_get_device_node (gdk_x11_device_get_id (device));
 }
 
 static gboolean


### PR DESCRIPTION
Regression in commit 88e9de536db46ed1bda3777d24e9305d694099c6. This was probably a bad merge from gnome. The HAVE_WAYLAND define is never defined, but if it did then the code would try to include a cinnamon header that has never existed, then call a gnome-settings-daemon internal function that does not exist.

It is possible to properly implement HAVE_WAYLAND, but this code didn't.