### PR TITLE
Cosmetic change: rename g-s-d to c-s-d

### DIFF
--- a/plugins/keyboard/csd-input-sources-switcher.c
+++ b/plugins/keyboard/csd-input-sources-switcher.c
@@ -50,8 +50,8 @@ do_switch (void)
   GVariant *sources;
   gint i, n;
 
-  /* FIXME: this is racy with the g-s-d media-keys plugin. Instead we
-     should have a DBus API on g-s-d and poke it from here.*/
+  /* FIXME: this is racy with the c-s-d media-keys plugin. Instead we
+     should have a DBus API on c-s-d and poke it from here.*/
   sources = g_settings_get_value (input_sources_settings, KEY_INPUT_SOURCES);
 
   n = g_variant_n_children (sources);

--- a/plugins/power/csd-backlight-helper.c
+++ b/plugins/power/csd-backlight-helper.c
@@ -164,8 +164,8 @@ main (int argc, char *argv[])
 	g_option_context_free (context);
 
 #ifndef __linux__
-	/* the g-s-d plugin should only call this helper on linux */
-	g_critical ("Attempting to call gsb-backlight-helper on non-Linux");
+	/* the c-s-d plugin should only call this helper on linux */
+	g_critical ("Attempting to call csd-backlight-helper on non-Linux");
 	g_assert_not_reached ();
 #endif
 

--- a/plugins/power/csd-power-manager.c
+++ b/plugins/power/csd-power-manager.c
@@ -4201,7 +4201,7 @@ on_rr_screen_acquired (GObject      *object,
         manager->priv->inhibit_lid_switch_enabled =
                           g_settings_get_boolean (manager->priv->settings, "inhibit-lid-switch");
 
-        /* Disable logind's lid handling while g-s-d is active */
+        /* Disable logind's lid handling while c-s-d is active */
         inhibit_lid_switch (manager);
 
         manager->priv->up_client = up_client_new ();


### PR DESCRIPTION
Initially I wanted to fix typo only in assertion message like
"Attempting to call gsb-backlight-helper on non-Linux"
Note gsb instead of gsd here as well.

But later I decided to change it everywhere.