### PR TITLE
plugins: Don't leak DESKTOP_AUTOSTART_ID into child processes

### DIFF
--- a/plugins/common/daemon-skeleton-gtk.h
+++ b/plugins/common/daemon-skeleton-gtk.h
@@ -161,6 +161,11 @@ register_with_cinnamon_session (void)
               NULL,
               (GAsyncReadyCallback) on_client_registered,
               NULL);
+
+   /* DESKTOP_AUTOSTART_ID must not leak into child processes, because
+    * it can't be reused. Child processes will not know whether this is
+    * a genuine value or erroneous already-used value. */
+   g_unsetenv ("DESKTOP_AUTOSTART_ID");
 }
 
 static gboolean

--- a/plugins/common/daemon-skeleton.h
+++ b/plugins/common/daemon-skeleton.h
@@ -156,6 +156,11 @@ register_with_cinnamon_session (GMainLoop *loop)
               NULL,
               (GAsyncReadyCallback) on_client_registered,
               loop);
+
+   /* DESKTOP_AUTOSTART_ID must not leak into child processes, because
+    * it can't be reused. Child processes will not know whether this is
+    * a genuine value or erroneous already-used value. */
+   g_unsetenv ("DESKTOP_AUTOSTART_ID");
 }
 
 static gboolean


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/commit/b8f302dd93483160e05f6473845c923495a2090a

https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/merge_requests/92

https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/issues/379

> This fixes error in applications started through media-keys:
> Gtk-WARNING **: 17:48:33.761: Failed to register client: GDBus.Error:org.gnome.SessionManager.AlreadyRegistered: Unable to register client

Specifically I encountered this issue when I failed to start `caja` in a GNOME Terminal started with keyboard shortcut `Ctrl+Alt+T` by `csd-media-keys`.
