### PR TITLE
csd-background: Remove decoration from desktop window

### DIFF
--- a/plugins/background/monitor-background.c
+++ b/plugins/background/monitor-background.c
@@ -63,6 +63,7 @@ build_monitor_background (MonitorBackground *mb)
 
     mb->window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
     gtk_window_set_type_hint (GTK_WINDOW (mb->window), GDK_WINDOW_TYPE_HINT_DESKTOP);
+    gtk_window_set_decorated (GTK_WINDOW (mb->window), FALSE);
 
     // Set keep below so muffin recognizes the backgrounds and keeps them
     // at the bottom of the bottom window layer (under file managers, etc..)


### PR DESCRIPTION
Without this, window decoration is drawn and the background is shifted in XWayland if `GTK_CSD=1` environment variable is set.

Similar fix was applied for nemo-desktop: https://github.com/linuxmint/nemo/pull/1512