### PR TITLE
csd-power-manager.c: Sent property updates when the percentage changes, not just an icon.

### DIFF
--- a/plugins/power/org.cinnamon.SettingsDaemon.Power.xml
+++ b/plugins/power/org.cinnamon.SettingsDaemon.Power.xml
@@ -6,6 +6,8 @@
   <interface name='org.cinnamon.SettingsDaemon.Power'>
     <property name='Icon' type='s' access='read'>
     </property>
+    <property name='Percentage' type='u' access='read'>
+    </property>
     <method name='GetPrimaryDevice'>
       <arg name='device' type='(sssusduut)' direction='out' />
     </method>


### PR DESCRIPTION
Commit c2c760960dd removed the Tooltip property from csd-power. We
weren't making use of that property anywhere in Cinnamon, but it
was doing the work of triggering updates there whenever the battery
percentage changed, keeping the applet up-to-date in between actual
icon changes.

There's no point in reverting everything - most is string handling
that we still don't need. Instead, implement a simple percentage
monitor and dbus Property to trigger updates for clients.

Fixes linuxmint/cinnamon#13324.
