### PR TITLE
Don't install the static csd library.

### DIFF
--- a/cinnamon-settings-daemon/meson.build
+++ b/cinnamon-settings-daemon/meson.build
@@ -20,8 +20,6 @@ csd_lib = static_library(
     csd_sources,
     include_directories: include_dirs,
     dependencies: csd_deps,
-    install: true,
-    install_dir: apilibdir,
 )
 
 csd_dep = declare_dependency(


### PR DESCRIPTION
The `libcsd.a` static library does not appear to be used outside of the build, and a pkg-config file hasn't been installed.

This came up in a downstream Gentoo bug about this binary having unstripped LTO bytecode. I figured the simplest solution was to not install it.