### PR TITLE
touchscreen: add disable-rotation-in-laptop-mode setting

### DIFF
--- a/data/org.cinnamon.settings-daemon.peripherals.gschema.xml.in.in
+++ b/data/org.cinnamon.settings-daemon.peripherals.gschema.xml.in.in
@@ -54,6 +54,11 @@
       <default>true</default>
       <summary>Whether the tablet's orientation is locked, or rotated automatically.</summary>
     </key>
+    <key name="disable-rotation-in-laptop-mode" type="b">
+      <default>true</default>
+      <summary>Do not auto-rotate the screen while in laptop mode.</summary>
+      <description>When automatic screen rotation is enabled, suppress it while the device is in laptop (clamshell) mode, following the accelerometer only once folded into tablet mode. Devices with no tablet-mode switch are unaffected.</description>
+    </key>
   </schema>
   <schema gettext-domain="@GETTEXT_PACKAGE@" id="org.cinnamon.settings-daemon.peripherals.input-devices" path="/org/cinnamon/settings-daemon/peripherals/input-devices/">
     <key name="hotplug-command" type="s">


### PR DESCRIPTION
Adds `disable-rotation-in-laptop-mode` (bool, default `true`) to the `…peripherals.touchscreen` schema.

It's the setting **Muffin reads** to gate accelerometer auto-rotation on tablet mode - companion to linuxmint/muffin#832 (which carries the actual behaviour). Requested in #359; the prior PR #361 implemented the gating in the csd *orientation plugin*, which was removed when orientation handling moved into Muffin - so this just adds the key, and the behaviour lives in Muffin now.

Happy to adjust the name/default or fold it into a different design - see the discussion on linuxmint/cinnamon#10697 (incl. @mtwebster's combobox idea, which the cinnamon-side PR implements).
