### PR TITLE
screensaver-proxy: stop losing track of inhibitors

### DIFF
--- a/plugins/screensaver-proxy/csd-screensaver-proxy-manager.c
+++ b/plugins/screensaver-proxy/csd-screensaver-proxy-manager.c
@@ -210,7 +210,7 @@ name_vanished_cb (GDBusConnection            *connection,
                 }
         }
 
-        g_hash_table_remove (manager->priv->watch_ht, sender);
+        g_hash_table_remove (manager->priv->watch_ht, name);
 }
 
 static void
@@ -277,6 +277,8 @@ handle_method_call (GDBusConnection       *connection,
                                         parameters,
                                         G_DBUS_CALL_FLAGS_NONE,
                                         -1, NULL, NULL);
+                g_hash_table_remove (manager->priv->cookie_ht,
+                                     GUINT_TO_POINTER (cookie));
                 g_dbus_method_invocation_return_value (invocation, NULL);
         } else if (g_strcmp0 (method_name, "Throttle") == 0) {
                 g_dbus_method_invocation_return_value (invocation, NULL);


### PR DESCRIPTION
## Summary

the csd-screensaver-proxy disconnect callback ends with:

`g_hash_table_remove (manager->priv->watch_ht, sender);`

But sender is merely the last hash-table entry inspected.

I tracked this down because I got sick of the game i'm developing crashing and causing my monitor to stay awake forever. the Cinnamon lock screen is burned into my OLED :(

## This PR:

- removes the name watch for the client that actually vanished instead of whichever sender happened to be visited last in the cookie hash table
- forget cookies after an explicit `UnInhibit`, preventing a second cleanup attempt and the resulting invalid-cookie error
- preserve cleanup watches for concurrent clients so a later crash cannot leave an idle inhibitor behind

## How i fixed the bug and tested my fix

- [x] configured and built the daemon with Meson
- [x] ran an isolated `dbus-run-session` test script with 12 concurrent clients and verified every cookie was released when its owning connection disappeared
- [x] verified a proper `UnInhibit` is forwarded exactly once when that client later disconnects
- [x] with the patch applied to my system i put a deliberate code error in my Godot-based game and spawned 20 game processes simultaneously, which would reliably reproduce the bug ten times out of ten on the unpatched proxy. 20 clients acquired inhibitors, all 20 were cleaned up on disconnect, and no invalid-cookie errors were logged