### PR TITLE
Power: Fix bug where power applet message is incorrect after adapter is plugged in.

### DIFF
--- a/plugins/power/csd-power-manager.c
+++ b/plugins/power/csd-power-manager.c
@@ -182,6 +182,7 @@ struct CsdPowerManagerPrivate
         gboolean                 use_time_primary;
         GIcon                   *previous_icon;
         guint                    previous_percentage;
+        guint                    previous_charge_state;
         GPtrArray               *devices_array;
         guint                    action_percentage;
         guint                    action_time;
@@ -441,7 +442,8 @@ typedef enum {
 static void
 engine_emit_changed (CsdPowerManager *manager,
                      gboolean         icon_changed,
-                     gboolean         percentage_changed)
+                     gboolean         percentage_changed,
+                     gboolean         charge_state_changed)
 {
         /* not yet connected to the bus */
         if (manager->priv->power_iface == NULL)
@@ -466,6 +468,12 @@ engine_emit_changed (CsdPowerManager *manager,
         if (percentage_changed) {
                 csd_power_set_percentage (manager->priv->power_iface,
                                           manager->priv->previous_percentage);
+                need_flush = TRUE;
+        }
+
+        if (charge_state_changed) {
+                csd_power_set_state (manager->priv->power_iface,
+                                     manager->priv->previous_charge_state);
                 need_flush = TRUE;
         }
 
@@ -791,18 +799,63 @@ engine_recalculate_state_percentage (CsdPowerManager *manager)
         return FALSE;
 }
 
+static guint
+engine_get_battery_charge_state (CsdPowerManager *manager)
+{
+        guint i;
+        GPtrArray *array;
+        UpDevice *device;
+        UpDeviceKind kind;
+        gboolean is_present;
+        UpDeviceState state = UP_DEVICE_STATE_UNKNOWN;
+
+        array = manager->priv->devices_array;
+        for (i = 0; i < array->len; i++) {
+                device = g_ptr_array_index (array, i);
+                g_object_get (device,
+                              "kind", &kind,
+                              "is-present", &is_present,
+                              NULL);
+
+                if (!is_present || kind != UP_DEVICE_KIND_BATTERY)
+                        continue;
+
+                device = engine_get_composite_device (manager, device);
+                g_object_get (device, "state", &state, NULL);
+                return (guint) state;
+        }
+
+        return (guint) UP_DEVICE_STATE_UNKNOWN;
+}
+
+static gboolean
+engine_recalculate_state_charge_state (CsdPowerManager *manager)
+{
+        guint charge_state;
+
+        charge_state = engine_get_battery_charge_state (manager);
+        if (manager->priv->previous_charge_state != charge_state) {
+                manager->priv->previous_charge_state = charge_state;
+                return TRUE;
+        }
+
+        return FALSE;
+}
+
 static void
 engine_recalculate_state (CsdPowerManager *manager)
 {
         gboolean icon_changed = FALSE;
         gboolean percentage_changed = FALSE;
+        gboolean charge_state_changed = FALSE;
 
         icon_changed = engine_recalculate_state_icon (manager);
         percentage_changed = engine_recalculate_state_percentage (manager);
+        charge_state_changed = engine_recalculate_state_charge_state (manager);
 
-        /* emit if the icon or percentage has changed */
-        if (icon_changed || percentage_changed)
-                engine_emit_changed (manager, icon_changed, percentage_changed);
+        /* emit if the icon, percentage, or charge state has changed */
+        if (icon_changed || percentage_changed || charge_state_changed)
+                engine_emit_changed (manager, icon_changed, percentage_changed, charge_state_changed);
 }
 
 static UpDevice *
@@ -4886,6 +4939,7 @@ csd_power_manager_init (CsdPowerManager *manager)
         manager->priv = CSD_POWER_MANAGER_GET_PRIVATE (manager);
         manager->priv->inhibit_lid_switch_fd = -1;
         manager->priv->inhibit_suspend_fd = -1;
+        manager->priv->previous_charge_state = G_MAXUINT;
 }
 
 static void

--- a/plugins/power/org.cinnamon.SettingsDaemon.Power.xml
+++ b/plugins/power/org.cinnamon.SettingsDaemon.Power.xml
@@ -8,6 +8,8 @@
     </property>
     <property name='Percentage' type='u' access='read'>
     </property>
+    <property name='State' type='u' access='read'>
+    </property>
     <method name='GetPrimaryDevice'>
       <arg name='device' type='(sssusduut)' direction='out' />
     </method>


### PR DESCRIPTION
## TLDR

Fixes  https://github.com/linuxmint/cinnamon/issues/13686 by making it so the [`PropertiesChanged`](https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-properties) D-Bus signal is emitted whenever the battery "state" changes which causes an immediate update to the power applet message. 

## Before

We use `watch -n 1 cat /sys/class/power_supply/BAT0/status ` to view the live state of the battery. When we plug in adapter, battery transitions to "not charging" and then quickly to "charging". the applet message transitions to "not charging" and will not update to "charging until the next percentage tick.


https://github.com/user-attachments/assets/64bfe631-33ac-4ec6-8942-9e01000529c4



## After

We use `watch -n 1 cat /sys/class/power_supply/BAT0/status` to view the live state of the battery. When we plug in adapter, battery state  transitions to "not charging" and then quickly to "charging" and applet message mirrors these transitions. 


https://github.com/user-attachments/assets/0f99f328-3ab0-4298-b458-dd8c37a9c20f








## Problem Description

When you plug in an adapter, for a brief moment the  battery "state" will be "pending-charge" (as reported by upower) as the system decides if this adapter being plugged in should allow the battery to charge. This resolves to message "not charging" on the applet. 


 However, the battery state will usually quickly  transition to "charging" once the system accepts the adapter as viable to allow the battery to charge. However, the message on the  power applet will remain as "not charging" until the next percentage tick. 

The reason for this is because the power applet message only gets updated when certain D-Bus properties change and a `PropertiesChanged` signal is emitted (via [`g_dbus_interface_skeleton_flush`](https://github.com/abebinder/cinnamon-settings-daemon/blob/charging_fix/plugins/power/csd-power-manager.c#L480-L481)), and the properties previously only included "percentage" and "icon".

The icon for "pending-charge" is [the same as "charging"](https://github.com/linuxmint/cinnamon-settings-daemon/blob/master/plugins/power/gpm-common.c#L206-L207) so a transition between pending-charge and charging does not  result in an update to the applet. Thus it waits for percentage to tick up before changing.  


## Summary of Fix


We add the battery "state" as a D-Bus property and [set it on the skeleton](https://github.com/abebinder/cinnamon-settings-daemon/blob/charging_fix/plugins/power/csd-power-manager.c#L474-L478) whenever it changes, then flush the skeleton which emits the `PropertiesChanged` signal. This triggers the power applet to refresh its display immediately.

Companion PR in cinnamon: https://github.com/linuxmint/cinnamon/pull/13945 (declares the new State property in the D-Bus interface XML)