### PR TITLE
power: Keep exported percentage tied to primary device

### DIFF
--- a/plugins/power/csd-power-manager.c
+++ b/plugins/power/csd-power-manager.c
@@ -48,6 +48,7 @@
 #include "cinnamon-settings-session.h"
 #include "csd-enums.h"
 #include "csd-power-manager.h"
+#include "csd-power-state.h"
 #include "csd-power-helper.h"
 #include "csd-power-proxy.h"
 #include "csd-power-screen-proxy.h"
@@ -761,8 +762,8 @@ engine_recalculate_state_percentage (CsdPowerManager *manager)
         UpDeviceKind kind;
         gboolean is_present;
         gdouble percentage;
-        guint percentage_uint;
         GPtrArray *array;
+        CsdPowerPercentageState state = { 0 };
 
         array = manager->priv->devices_array;
         for (i = 0; i < array->len; i++) {
@@ -770,25 +771,24 @@ engine_recalculate_state_percentage (CsdPowerManager *manager)
                 g_object_get (device,
                               "kind", &kind,
                               "is-present", &is_present,
-                              "percentage", &percentage,
                               NULL);
-
-                if (!is_present)
-                        continue;
 
                 if (kind == UP_DEVICE_KIND_BATTERY)
                         device = engine_get_composite_device (manager, device);
 
                 g_object_get (device, "percentage", &percentage, NULL);
-                percentage_uint = (guint) CLAMP (percentage, 0.0, 100.0);
-
-                if (manager->priv->previous_percentage != percentage_uint) {
-                        manager->priv->previous_percentage = percentage_uint;
-                        return TRUE;
-                }
+                csd_power_percentage_state_consider (&state,
+                                                     kind,
+                                                     is_present,
+                                                     percentage);
         }
 
-        return FALSE;
+        if (!state.valid ||
+            manager->priv->previous_percentage == state.percentage)
+                return FALSE;
+
+        manager->priv->previous_percentage = state.percentage;
+        return TRUE;
 }
 
 static void

--- a/plugins/power/csd-power-state.c
+++ b/plugins/power/csd-power-state.c
@@ -1,0 +1,47 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "config.h"
+
+#include "csd-power-state.h"
+
+static guint
+percentage_kind_priority (UpDeviceKind kind)
+{
+        if (kind == UP_DEVICE_KIND_BATTERY)
+                return 2;
+        if (kind == UP_DEVICE_KIND_UPS)
+                return 1;
+        return 0;
+}
+
+void
+csd_power_percentage_state_consider (CsdPowerPercentageState *state,
+                                     UpDeviceKind             kind,
+                                     gboolean                 is_present,
+                                     gdouble                  percentage)
+{
+        guint priority;
+
+        g_return_if_fail (state != NULL);
+
+        if (!is_present)
+                return;
+
+        priority = percentage_kind_priority (kind);
+        if (priority == 0)
+                return;
+
+        if (state->valid &&
+            priority <= percentage_kind_priority (state->kind))
+                return;
+
+        state->valid = TRUE;
+        state->kind = kind;
+        state->percentage = (guint) CLAMP (percentage, 0.0, 100.0);
+}

--- a/plugins/power/csd-power-state.h
+++ b/plugins/power/csd-power-state.h
@@ -1,0 +1,30 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef __CSD_POWER_STATE_H
+#define __CSD_POWER_STATE_H
+
+#include <glib.h>
+#include <libupower-glib/upower.h>
+
+G_BEGIN_DECLS
+
+typedef struct {
+        gboolean     valid;
+        UpDeviceKind kind;
+        guint        percentage;
+} CsdPowerPercentageState;
+
+void csd_power_percentage_state_consider (CsdPowerPercentageState *state,
+                                          UpDeviceKind             kind,
+                                          gboolean                 is_present,
+                                          gdouble                  percentage);
+
+G_END_DECLS
+
+#endif /* __CSD_POWER_STATE_H */

--- a/plugins/power/meson.build
+++ b/plugins/power/meson.build
@@ -29,6 +29,7 @@ power_keyboard_proxy = gnome.gdbus_codegen(
 
 power_sources = [
     'csd-power-manager.c',
+    'csd-power-state.c',
     'gpm-common.c',
     'main.c',
     power_proxy,
@@ -51,6 +52,18 @@ power_deps = [
     upower_glib,
     xext,
 ]
+
+test_power_state = executable(
+    'test-power-state',
+    [
+        'test-power-state.c',
+        'csd-power-state.c',
+    ],
+    include_directories: [include_dirs, common_inc],
+    dependencies: [glib, upower_glib],
+)
+
+test('power-state', test_power_state)
 
 executable(
     'csd-power',

--- a/plugins/power/test-power-state.c
+++ b/plugins/power/test-power-state.c
@@ -1,0 +1,69 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "config.h"
+
+#include <glib.h>
+
+#include "csd-power-state.h"
+
+static void
+assert_peripheral_does_not_replace_battery (void)
+{
+        CsdPowerPercentageState state = { 0 };
+
+        csd_power_percentage_state_consider (&state,
+                                             UP_DEVICE_KIND_BATTERY,
+                                             TRUE,
+                                             85.0);
+        csd_power_percentage_state_consider (&state,
+                                             UP_DEVICE_KIND_HEADSET,
+                                             TRUE,
+                                             80.0);
+
+        g_assert_true (state.valid);
+        g_assert_cmpint (state.kind, ==, UP_DEVICE_KIND_BATTERY);
+        g_assert_cmpuint (state.percentage, ==, 85);
+}
+
+static void
+assert_ups_is_fallback (void)
+{
+        CsdPowerPercentageState state = { 0 };
+
+        csd_power_percentage_state_consider (&state,
+                                             UP_DEVICE_KIND_UPS,
+                                             TRUE,
+                                             42.0);
+
+        g_assert_true (state.valid);
+        g_assert_cmpint (state.kind, ==, UP_DEVICE_KIND_UPS);
+        g_assert_cmpuint (state.percentage, ==, 42);
+
+        csd_power_percentage_state_consider (&state,
+                                             UP_DEVICE_KIND_BATTERY,
+                                             TRUE,
+                                             85.0);
+
+        g_assert_true (state.valid);
+        g_assert_cmpint (state.kind, ==, UP_DEVICE_KIND_BATTERY);
+        g_assert_cmpuint (state.percentage, ==, 85);
+}
+
+int
+main (int argc, char **argv)
+{
+        g_test_init (&argc, &argv, NULL);
+
+        g_test_add_func ("/power/percentage/peripheral-does-not-replace-battery",
+                         assert_peripheral_does_not_replace_battery);
+        g_test_add_func ("/power/percentage/ups-fallback",
+                         assert_ups_is_fallback);
+
+        return g_test_run ();
+}


### PR DESCRIPTION
`engine_recalculate_state_percentage()` compares each present UPower device with one shared previous percentage. With a system battery and Bluetooth peripheral, this can alternate the exported `Percentage` and continuously emit `PropertiesChanged`.

Select one percentage per recalculation: prefer a present system battery, fall back to a UPS, and ignore peripheral batteries. Composite battery handling is unchanged.

On the test system, a same-source 6.6.4 A/B validation (12 runs per variant and hardware state, 30 seconds each) reduced the AC plugged + Bluetooth connected case from 188.7 to 0 outgoing messages per observation, `csd-power` CPU from 0.336% to 0.044% of one core, and context switches from 10.47 to 0.75/s. The `power-state` regression test passes.

Fixes #455

